### PR TITLE
Use array() syntax.

### DIFF
--- a/src/MomentLocale.php
+++ b/src/MomentLocale.php
@@ -89,7 +89,7 @@ class MomentLocale
      *
      * @return string
      */
-    public static function renderLocaleString(array $localeKeys, $formatArgs = [])
+    public static function renderLocaleString(array $localeKeys, $formatArgs = array())
     {
         // get locale handler
         $localeString = self::getLocaleString($localeKeys);


### PR DESCRIPTION
The README.md file says the minimum PHP version must be 5.3
but this version doesn't support the square brackets syntax.