### PR TITLE
Use locale day of week in getPeriod("week")

### DIFF
--- a/src/Locales/en_US.php
+++ b/src/Locales/en_US.php
@@ -5,5 +5,6 @@
 $locale = require __DIR__ . '/en_GB.php';
 $locale['calendar']['withTime'] = '[at] h:i A';
 $locale['calendar']['default'] = 'm/d/Y';
+$locale['week']['dow'] = 7;
 
 return $locale;

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -619,14 +619,16 @@ class Moment extends \DateTime
                 $currentWeekDay = $this->format('N');
                 $interval = $this->format('W');
 
+                $dow = MomentLocale::getLocaleString(array('week','dow'), array($this));
+
                 $start = new Moment('@' . $this->format('U'));
                 $start->setTimezone($this->getTimezoneString())
-                    ->subtractDays($currentWeekDay - 1)
+                    ->subtractDays($currentWeekDay - $dow)
                     ->setTime(0, 0, 0);
 
                 $end = new Moment('@' . $this->format('U'));
                 $end->setTimezone($this->getTimezoneString())
-                    ->addDays(7 - $currentWeekDay)
+                    ->addDays((($dow + 6) % 7) - $currentWeekDay)
                     ->setTime(23, 59, 59);
 
                 break;

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -616,19 +616,16 @@ class Moment extends \DateTime
         switch ($period)
         {
             case 'week':
-                $currentWeekDay = $this->format('N');
                 $interval = $this->format('W');
-
-                $dow = MomentLocale::getLocaleString(array('week','dow'), array($this));
 
                 $start = new Moment('@' . $this->format('U'));
                 $start->setTimezone($this->getTimezoneString())
-                    ->subtractDays($currentWeekDay - $dow)
+                    ->subtractDays($this->getDaysAfterStartOfWeek())
                     ->setTime(0, 0, 0);
 
                 $end = new Moment('@' . $this->format('U'));
                 $end->setTimezone($this->getTimezoneString())
-                    ->addDays((($dow + 6) % 7) - $currentWeekDay)
+                    ->addDays(6 - $this->getDaysAfterStartOfWeek())
                     ->setTime(23, 59, 59);
 
                 break;
@@ -941,6 +938,18 @@ class Moment extends \DateTime
         $this->setTimezoneString($timezoneString);
 
         return new \DateTimeZone($timezoneString);
+    }
+
+    /**
+     * @return int
+     */
+    private function getDaysAfterStartOfWeek()
+    {
+        $dow = MomentLocale::getLocaleString(array('week','dow'), array($this)) % 7;
+        $currentWeekDay = (int) $this->getWeekday();
+        $distance = (7 - $dow + $currentWeekDay ) % 7;
+
+        return $distance;
     }
 
     /**

--- a/tests/src/Moment/MomentTest.php
+++ b/tests/src/Moment/MomentTest.php
@@ -419,6 +419,24 @@ class MomentTest extends \PHPUnit_Framework_TestCase
 
     }
 
+    public function testLocaleDow()
+    {
+        //Test en_GB for Monday start of week
+        Moment::setLocale('en_GB');
+
+        $gb = new Moment('2014-03-09T10:29:00Z');
+        $this->assertEquals(1, $gb->startOf('week')->getWeekday());
+        $this->assertEquals(7, $gb->endOf('week')->getWeekday());
+
+        //Test en_US for Sunday start of week
+        Moment::setLocale('en_US');
+
+        $us = new Moment('2014-03-09T10:29:00Z');
+        $this->assertEquals(7, $us->startOf('week')->getWeekday());
+        $this->assertEquals(6, $us->endOf('week')->getWeekday());
+
+    }
+
 // TODO: have a look when I am coming back to this pull request
 //    public function testToArray()
 //    {

--- a/tests/src/Moment/MomentTest.php
+++ b/tests/src/Moment/MomentTest.php
@@ -424,16 +424,54 @@ class MomentTest extends \PHPUnit_Framework_TestCase
         //Test en_GB for Monday start of week
         Moment::setLocale('en_GB');
 
-        $gb = new Moment('2014-03-09T10:29:00Z');
-        $this->assertEquals(1, $gb->startOf('week')->getWeekday());
-        $this->assertEquals(7, $gb->endOf('week')->getWeekday());
+        //Expected Values
+        $gb_start = new Moment('2015-04-27T00:00:00Z');
+        $gb_end = new Moment('2015-05-03T23:59:59Z');
+
+        //Current date: Middle of the week
+        $gb = new Moment('2015-04-28T10:29:00Z');
+
+        $this->assertTrue($gb->cloning()->startOf('week')->isSame($gb_start));
+        $this->assertTrue($gb->cloning()->endOf('week')->isSame($gb_end));
+
+        //Current Date: Beginning of the week
+        $gb = new Moment('2015-04-27T10:29:00Z');
+
+        $this->assertTrue($gb->cloning()->startOf('week')->isSame($gb_start));
+        $this->assertTrue($gb->cloning()->endOf('week')->isSame($gb_end));
+
+        //Current Date: End of week
+        $gb = new Moment('2015-05-03T10:29:00Z');
+
+        $this->assertTrue($gb->cloning()->startOf('week')->isSame($gb_start));
+        $this->assertTrue($gb->cloning()->endOf('week')->isSame($gb_end));
+
 
         //Test en_US for Sunday start of week
         Moment::setLocale('en_US');
 
-        $us = new Moment('2014-03-09T10:29:00Z');
-        $this->assertEquals(7, $us->startOf('week')->getWeekday());
-        $this->assertEquals(6, $us->endOf('week')->getWeekday());
+        //Expected Values
+        $us_start = new Moment('2015-04-26T00:00:00Z');
+        $us_end = new Moment('2015-05-02T23:59:59Z');
+
+        //Current date: Middle of the week
+        $us = new Moment('2015-04-28T10:29:00Z');
+
+        $this->assertTrue($us->cloning()->startOf('week')->isSame($us_start));
+        $this->assertTrue($us->cloning()->endOf('week')->isSame($us_end));
+
+        //Current Date: Beginning of the week
+        $us = new Moment('2015-04-26T10:29:00Z');
+
+        $this->assertTrue($us->cloning()->startOf('week')->isSame($us_start));
+        $this->assertTrue($us->cloning()->endOf('week')->isSame($us_end));
+
+        //Current Date: End of week
+        $us = new Moment('2015-05-02T10:29:00Z');
+
+        $this->assertTrue($us->cloning()->startOf('week')->isSame($us_start));
+        $this->assertTrue($us->cloning()->endOf('week')->isSame($us_end));
+
 
     }
 


### PR DESCRIPTION
Fix for #47: The `getPeriod()` method does not take in to account the locale when finding the start and end of a week. This change pulls in the locale setting and considers it in the calculation. This also adds a unit test for Monday and Sunday start days.