### PR TITLE
Fix README reference to pt_BR locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ __Supported languages so far:__
 ```en_US``` English  (American)  
 ```es_ES``` Spanish (Europe)  
 ```fr_FR``` French (Europe)  
-```pt_BR``` Portuguese (Europe)  
+```pt_BR``` Portuguese (Brazil)  
 ```it_IT``` Italian  
 ```th_TH``` Thai  
 ```zh_CN``` Chinese  


### PR DESCRIPTION
According to the ISO 3166-1 alpha-2 codes, `pt_BR` represents the Portuguese language spoken in
Brazil. The one for Portugal is `pt_PT`.