### PR TITLE
Added Immutable Mode; updated README and added test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <pre>
                                       _           _           
  _ __ ___   ___  _ __ ___   ___ _ __ | |_   _ __ | |__  _ __  
-| '_ ` _ \ / _ \| '_ ` _ \ / _ \ '_ \| __| | '_ \| '_ \| '_ \ 
+| '_ ` _ \ / _ \| '_ ` _ \ / _ \ '_ \| __| | '_ \| '_ \| '_ \
 | | | | | | (_) | | | | | |  __/ | | | |_ _| |_) | | | | |_) |
-|_| |_| |_|\___/|_| |_| |_|\___|_| |_|\__(_) .__/|_| |_| .__/ 
+|_| |_| |_|\___/|_| |_| |_|\___|_| |_|\__(_) .__/|_| |_| .__/
                                            |_|         |_|    
 </pre>
 
@@ -54,7 +54,7 @@ echo $m->format(); // e.g. 2012-10-03T12:00:00+0200
 
 ### Switch locale
 
-Have a look at the ```Locales``` folder to see all supported languages. Default locale is ```en_GB```. 
+Have a look at the ```Locales``` folder to see all supported languages. Default locale is ```en_GB```.
 
 ```php
 $m = new \Moment\Moment();
@@ -64,7 +64,7 @@ echo $m->format('[Weekday:] l'); // e.g. Weekday: Wednesday
 \Moment\Moment::setLocale('de_DE');
 
 $m = new \Moment\Moment();
-echo $m->format('[Wochentag:] l'); // e.g. Wochentag: Mittwoch 
+echo $m->format('[Wochentag:] l'); // e.g. Wochentag: Mittwoch
 ```
 
 __Supported languages so far:__
@@ -171,10 +171,27 @@ Sometimes its useful to take a given moment and work with it without changing th
 ```php
 $m = new \Moment\Moment('2012-05-15T12:30:00', 'CET');
 $c = $m->cloning()->addDays(1);
- 
+
 echo $m->getDay(); // 15
 echo $c->getDay(); // 16
 ```
+
+Alternately, you can enable immutable mode on the origin.
+
+```php
+$m = new \Moment\Moment('2012-05-15T12:30:00', 'CET', true);
+$c = $m->addDays(1);
+
+echo $m->getDay(); // 15
+echo $c->getDay(); // 16
+
+// You can also change the immutable mode after creation:
+$m->setImmutableMode(false)->subtractDays(1);
+
+echo $m->getDay(); // 14
+```
+
+Immutable mode makes all modification methods call `cloning()` implicitly before applying their modifications.
 
 #### III. Methods for manipulating the date/time
 
@@ -313,11 +330,11 @@ __Note:__ I ignored the period of ```second``` since we are not dealing with mil
 
 -------------------------------------------------
 
-### Get dates for given weekdays for upcoming weeks 
+### Get dates for given weekdays for upcoming weeks
 
 For one of my customers I needed to get moments by selected weekdays. __The task was:__ give me the dates for
 ```Tuesdays``` and ```Thursdays``` for the next three weeks. So I added a small handler which does exactly this.
-As result you will receive an array filled with ```Moment Objects```. 
+As result you will receive an array filled with ```Moment Objects```.
 
 ```php
 // 1 - 7 = Mon - Sun
@@ -344,6 +361,10 @@ You can now run through the result and put it formatted into a drop-down field o
 -------------------------------------------------
 
 # Changelog
+
+### 1.18.0
+- added:
+    - Immutable mode
 
 ### 1.17.0
 - added:
@@ -375,25 +396,25 @@ You can now run through the result and put it formatted into a drop-down field o
 
 ### 1.11.4
 - fixed:
-    - fixed starting/ending weekday for Romanian locale 
+    - fixed starting/ending weekday for Romanian locale
 
 ### 1.11.3
 - fixed:
-    - adding delimiter character to Italian locale 
+    - adding delimiter character to Italian locale
 
 ### 1.11.1
 - fixed:
-    - passing back new instance for startOf/endOf for week, month, quarter 
+    - passing back new instance for startOf/endOf for week, month, quarter
 
 ### 1.11.0
 - added:
-    - locale Czech 
+    - locale Czech
 
 ### 1.10.4
 - added:
-    - ```calendar``` locale receives as \Closure the following params ```function(Moment $m) {}``` 
-    - ```relativeTime``` locale receives as \Closure the following params ```function($count, $direction, Moment $m) {}``` 
-    
+    - ```calendar``` locale receives as \Closure the following params ```function(Moment $m) {}```
+    - ```relativeTime``` locale receives as \Closure the following params ```function($count, $direction, Moment $m) {}```
+
 ### 1.10.3
 - added:
     - fixed passing closures to locale (calendar, relativeTime)
@@ -435,11 +456,11 @@ You can now run through the result and put it formatted into a drop-down field o
     - getWeekdayNameShort()
     - getMonthNameLong()
     - getMonthNameShort()
-    
+
 ### 1.7.0
 - added:
     - Locale: Thai
-    
+
 ### 1.6.0
 - added:
     - Locale
@@ -458,11 +479,11 @@ You can now run through the result and put it formatted into a drop-down field o
     - MomentFromVo:
         - direction returns now: "future" (-) / "past" (+)
         - time values are now type casted as floats
-    
+
 ### 1.5.2
 - fixed:
     - unrecognised timezone when constructing a Moment
-    
+
 ### 1.5.1
 - added:
     - getMomentsByWeekdays()
@@ -500,15 +521,15 @@ You can now run through the result and put it formatted into a drop-down field o
         - e.g. ```WS``` for 21th week of the year shows now correct ```21th``` etc.
     - you can now escape text by wrapping it in ```[]```
         - e.g. ```[Hello World]``` will be automatically transformed into ```\H\e\l\l\o \W\o\r\l\d```
-    
+
 - removed:
     - add()
     - subtract()
-    
+
 ### 1.4.0
 - added:
     - calendar format as implemented by [moment.js](http://momentjs.com/docs/#/displaying/calendar-time/)
-    
+
 ### 1.3.0
 - fixed:
     - incompatibility w/ PHP 5.3
@@ -516,7 +537,7 @@ You can now run through the result and put it formatted into a drop-down field o
 - added:
     - Exception throw as ```MomentException```
     - Date validation on instantiation:
-        - test for dates w/ format ```YYYY-mm-dd``` and ```YYYY-mm-ddTHH:ii:ss``` 
+        - test for dates w/ format ```YYYY-mm-dd``` and ```YYYY-mm-ddTHH:ii:ss```
         - throws MomentException on invalid dates
     - addSeconds()
     - addMinutes()
@@ -536,7 +557,7 @@ You can now run through the result and put it formatted into a drop-down field o
 - deprecated:
     - add()
     - subtract()
-    
+
 -------------------------------------------------
 
 # License

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -22,6 +22,11 @@ class Moment extends \DateTime
     private $timezoneString;
 
     /**
+     * @var boolean
+     */
+    private $immutableMode;
+
+    /**
      * @param string $locale
      *
      * @return void
@@ -33,12 +38,26 @@ class Moment extends \DateTime
     }
 
     /**
+     * @param boolean $mode
+     *
+     * @return self
+     */
+    public function setImmutableMode($mode)
+    {
+        // set immutable mode to true or false
+        $this->immutableMode = $mode;
+
+        return $this;
+    }
+
+    /**
      * @param string $dateTime
      * @param string $timezone
+     * @param bool $immutableMode
      *
      * @throws MomentException
      */
-    public function __construct($dateTime = 'now', $timezone = 'UTC')
+    public function __construct($dateTime = 'now', $timezone = 'UTC', $immutableMode = false)
     {
         // set moment
         MomentLocale::setMoment($this);
@@ -46,7 +65,11 @@ class Moment extends \DateTime
         // load locale content
         MomentLocale::loadLocaleContent();
 
-        return $this->resetDateTime($dateTime, $timezone);
+        // initialize DateTime
+        $this->resetDateTime($dateTime, $timezone);
+
+        // set immutable mode
+        $this->setImmutableMode($immutableMode);
     }
 
     /**
@@ -58,6 +81,11 @@ class Moment extends \DateTime
      */
     public function resetDateTime($dateTime = 'now', $timezoneString = 'UTC')
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         // cache dateTime
         $this->setRawDateTimeString($dateTime);
 
@@ -86,6 +114,11 @@ class Moment extends \DateTime
      */
     public function setTimezone($timezone)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         $this->setTimezoneString($timezone);
 
         parent::setTimezone($this->getDateTimeZone($timezone));
@@ -411,6 +444,25 @@ class Moment extends \DateTime
     }
 
     /**
+     * @param int $year
+     * @param int $month
+     * @param int $day
+     *
+     * @return self|\DateTime
+     */
+    public function setDate($year, $month, $day)
+    {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
+        parent::setDate($year, $month, $day);
+
+        return $this;
+    }
+
+    /**
      * @param $second
      *
      * @return Moment
@@ -479,6 +531,11 @@ class Moment extends \DateTime
      */
     public function setTime($hour, $minute, $second = null)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         parent::setTime($hour, $minute, $second);
 
         return $this;
@@ -544,6 +601,11 @@ class Moment extends \DateTime
      */
     private function addTime($type = 'day', $value = 1)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         parent::modify('+' . $value . ' ' . $type);
 
         return $this;
@@ -855,6 +917,23 @@ class Moment extends \DateTime
     }
 
     /**
+     * @param string $method
+     * @param array $params
+     *
+     * @return self
+     */
+    private function implicitCloning($method, $params = array())
+    {
+        $clone = $this->cloning();
+
+        $clone->setImmutableMode(false);
+        $retval = call_user_func_array(array($clone, $method), $params);
+        $clone->setImmutableMode(true);
+
+        return is_null($retval) ? $clone : $retval;
+    }
+
+    /**
      * @param array $weekdayNumbers
      * @param int $forUpcomingWeeks
      *
@@ -894,6 +973,11 @@ class Moment extends \DateTime
      */
     private function setRawDateTimeString($rawDateTimeString)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         $this->rawDateTimeString = $rawDateTimeString;
 
         return $this;
@@ -914,6 +998,11 @@ class Moment extends \DateTime
      */
     private function setTimezoneString($timezoneString)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         $this->timezoneString = $timezoneString;
 
         return $this;
@@ -1038,6 +1127,11 @@ class Moment extends \DateTime
      */
     private function subtractTime($type = 'day', $value = 1)
     {
+        if ($this->immutableMode)
+        {
+            return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
         parent::modify('-' . $value . ' ' . $type);
 
         return $this;

--- a/tests/unit/Moment/MomentTest.php
+++ b/tests/unit/Moment/MomentTest.php
@@ -439,6 +439,17 @@ class MomentTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($us->cloning()->endOf('week')->isSame($us_end));
     }
 
+    public function testImplicitCloning()
+    {
+        $origin = new Moment('1923-12-31 12:30:00', 'UTC', true);
+
+        $this->assertNotSame($origin, $origin->addMonths(1));
+        $origin->setImmutableMode(false);
+        $this->assertSame($origin, $origin->addMonths(1));
+        $origin->setImmutableMode(true);
+        $this->assertNotSame($origin, $origin->addMonths(1));
+    }
+
     /**
      * @link https://github.com/fightbulc/moment.php/issues/62
      */


### PR DESCRIPTION
In response to #28, here is a PR that adds Immutable Mode!  When enabled, any modifications will first trigger a clone, and then the actual modifications will be performed on the clone instead of the origin.  It is possible to turn Immutable Mode on or off as needed, so you can temporarily unlock an object to make changes directly to it, then lock it again afterward.  A test has been added to verify that Immutable Mode does, in fact, make clones when changes are made, and that it can be toggled on and off after the object is constructed.  The README was also updated to reflect the new usage.

Signed-off-by: Daniel Hunsaker <danhunsaker@gmail.com>