### PR TITLE
Updated incorrect order of weekdays for hu_HU locale

### DIFF
--- a/src/Locales/hu_HU.php
+++ b/src/Locales/hu_HU.php
@@ -8,7 +8,7 @@ return array(
 
     "monthsShort"   => explode('_', 'jan_feb_márc_ápr_máj_jún_júl_aug_szept_okt_nov_dec'),
     "weekdays"      => explode('_', 'hétfő_kedd_szerda_csütörtök_péntek_szombat_vasárnap'),
-    "weekdaysShort" => explode('_', 'vas_hét_kedd_sze_csüt_pén_szo'),
+    "weekdaysShort" => explode('_', 'hét_kedd_sze_csüt_pén_szo_vas'),
     "calendar"      => array(
         "sameDay"  => '[ma] l[-kor]',
         "nextDay"  => '[holnap] l[-kor]',

--- a/src/Locales/hu_HU.php
+++ b/src/Locales/hu_HU.php
@@ -7,7 +7,7 @@ return array(
     "months"        => explode('_', 'január_február_március_április_május_június_július_augusztus_szeptember_október_november_december'),
 
     "monthsShort"   => explode('_', 'jan_feb_márc_ápr_máj_jún_júl_aug_szept_okt_nov_dec'),
-    "weekdays"      => explode('_', 'vasárnap_hétfő_kedd_szerda_csütörtök_péntek_szombat'),
+    "weekdays"      => explode('_', 'hétfő_kedd_szerda_csütörtök_péntek_szombat_vasárnap'),
     "weekdaysShort" => explode('_', 'vas_hét_kedd_sze_csüt_pén_szo'),
     "calendar"      => array(
         "sameDay"  => '[ma] l[-kor]',


### PR DESCRIPTION
The weekdays for the hu_HU locale were in an incorrect order (sunday to saturday, insteaf of monday to sunday), making the translations incorrect. This is now fixed.