### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": {

--- a/tests/unit/Moment/MomentFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentFrenchLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentFrenchLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentFrenchLocaleTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Moment/MomentGermanLocaleTest.php
+++ b/tests/unit/Moment/MomentGermanLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentGermanLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentGermanLocaleTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Moment/MomentPolishLocaleTest.php
+++ b/tests/unit/Moment/MomentPolishLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentPolishLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentPolishLocaleTest extends TestCase
 {
     public function setUp()
     {
@@ -100,22 +102,22 @@ class MomentPolishLocaleTest extends \PHPUnit_Framework_TestCase
 
         $past = new Moment('2016-04-11');
         $this->assertEquals('ostatni poniedziałek', $past->calendar(false, new Moment('2016-04-17')));
-        
+
         $past = new Moment('2016-04-12');
         $this->assertEquals('ostatni wtorek', $past->calendar(false, new Moment('2016-04-17')));
-        
+
         $past = new Moment('2016-04-13');
         $this->assertEquals('ostatnia środa', $past->calendar(false, new Moment('2016-04-17')));
-        
+
         $past = new Moment('2016-04-14');
         $this->assertEquals('ostatni czwartek', $past->calendar(false, new Moment('2016-04-17')));
 
         $past = new Moment('2016-04-15');
         $this->assertEquals('ostatni piątek', $past->calendar(false, new Moment('2016-04-17')));
-        
+
         $past = new Moment('2016-04-16');
         $this->assertEquals('wczoraj', $past->calendar(false, new Moment('2016-04-17')));
-        
+
         $past = new Moment('2016-04-16');
         $this->assertEquals('ostatnia sobota', $past->calendar(false, new Moment('2016-04-18')));
     }

--- a/tests/unit/Moment/MomentRussianLocaleTest.php
+++ b/tests/unit/Moment/MomentRussianLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentRussianLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentRussianLocaleTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Moment/MomentTest.php
+++ b/tests/unit/Moment/MomentTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentTest extends TestCase
 {
     public function testMoment()
     {

--- a/tests/unit/Moment/MomentTurkishLocaleTest.php
+++ b/tests/unit/Moment/MomentTurkishLocaleTest.php
@@ -7,7 +7,9 @@
 
 namespace Moment;
 
-class MomentTurkishLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentTurkishLocaleTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Moment/MomentUkrainianLocaleTest.php
+++ b/tests/unit/Moment/MomentUkrainianLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentUkrainianLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentUkrainianLocaleTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md), that support this namespace.