### PR TITLE
OOP (dependency injection) way of defining locales

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ $m = new \Moment\Moment();
 echo $m->format('[Wochentag:] l'); // e.g. Wochentag: Mittwoch
 ```
 
+Another way to set locale in OOP fashion (dependency injection):
+```php
+// set Norwegian locale - at this very moment, only supported for this way
+\Moment\Moment::setLocale(new \Moment\Locales\no_NB());
+
+// You can also override locale definitions on the fly:
+\Moment\Moment::setLocale(new \Moment\Locales\no_NB([
+    'relativeTime' => [
+        'future' => 'in %s'
+    ]
+]));
+
+(...)
+```
+
 __Supported languages so far:__
 
 ```ar_TN``` Arabic (Tunisia)  
@@ -125,6 +140,7 @@ __Supported languages so far:__
 ```ru_RU``` Russian (Basic version)  
 ```es_ES``` Spanish (Europe)  
 ```se_SV``` Swedish  
+```no_NB``` Norwegian
 ```uk_UA``` Ukrainian  
 ```th_TH``` Thai  
 ```tr_TR``` Turkish  
@@ -416,6 +432,13 @@ You can now run through the result and put it formatted into a drop-down field o
 -------------------------------------------------
 
 # Changelog
+
+### 1.27.0
+ - added:
+    - OOP way of setting locale (dependency injection)
+      - Allows shipping locales in separate composer modules
+      - Allows overriding definitions of locale on the fly
+    - Norwegian locale (no_NB)
 
 ### 1.26.10
  - fixed:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Date library for parsing, manipulating and formatting dates w/ i18n.
 
 ### Any dependencies?
 
-PHP 5.3 or later since moment.php is based on php's [DateTime Class](http://php.net/manual/en/class.datetime.php).
+PHP 5.4 or later since moment.php is based on php's [DateTime Class](http://php.net/manual/en/class.datetime.php).
 
 -------------------------------------------------
 
@@ -103,7 +103,7 @@ echo $m->format('[Wochentag:] l'); // e.g. Wochentag: Mittwoch
 
 Another way to set locale in OOP fashion (dependency injection):
 ```php
-// set Norwegian locale - at this very moment, only supported for this way
+// set Norwegian locale - at this very moment, few locales are supported for this way
 \Moment\Moment::setLocale(new \Moment\Locales\no_NB());
 
 // You can also override locale definitions on the fly:
@@ -432,6 +432,16 @@ You can now run through the result and put it formatted into a drop-down field o
 -------------------------------------------------
 
 # Changelog
+
+### 2.0.0
+ - fixed:
+    - en_GB OOP
+    - sv_SE OOP
+    - pt_BR OOP
+    - pt_PT OOP
+    - fr_FR
+ - other:
+    - Locales uses new array syntax, therefore killing < PHP5.4 support (PHP5.3)
 
 ### 1.27.0
  - added:

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
         "psr-4": {
             "Moment\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Moment\\Tests\\": "tests/unit"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.2.*"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "php": ">=5.4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.2.*"
+        "phpunit/phpunit": "4.2.*",
+        "jakub-onderka/php-parallel-lint": "^0.9.2",
+        "jakub-onderka/php-console-highlighter": "^0.3.2"
     },
     "autoload": {
         "psr-4": {
@@ -48,5 +50,9 @@
         "psr-4": {
             "Moment\\Tests\\": "tests/unit"
         }
+    },
+    "scripts": {
+        "test": "phpunit -c tests/build.xml",
+        "php-lint": "parallel-lint . -s --blame --exclude vendor --exclude tests -p php"
     }
 }

--- a/src/Helpers/ArrayHelpers.php
+++ b/src/Helpers/ArrayHelpers.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Moment\Helpers;
+
+/**
+ * Class ArrayHelperFunctions
+ * @package Moment\Helpers
+ */
+class ArrayHelpers
+{
+    /**
+     * array_merge_recursive does indeed merge arrays, but it converts values with duplicate
+     * keys to arrays rather than overwriting the value in the first array with the duplicate
+     * value in the second array, as array_merge does. I.e., with array_merge_recursive,
+     * this happens (documented behavior):
+     *
+     * array_merge_recursive(array('key' => 'org value'), array('key' => 'new value'));
+     *     => array('key' => array('org value', 'new value'));
+     *
+     * array_merge_recursive_distinct does not change the datatypes of the values in the arrays.
+     * Matching keys' values in the second array overwrite those in the first array, as is the
+     * case with array_merge, i.e.:
+     *
+     * array_merge_recursive_distinct(array('key' => 'org value'), array('key' => 'new value'));
+     *     => array('key' => array('new value'));
+     *
+     * Parameters are passed by reference, though only for performance reasons. They're not
+     * altered by this function.
+     *
+     * @param array $array1
+     * @param array $array2
+     *
+     * @return array
+     *
+     * @see http://php.net/manual/en/function.array-merge-recursive.php#92195
+     * @author Daniel <daniel (at) danielsmedegaardbuus (dot) dk>
+     * @author Gabriel Sobrinho <gabriel (dot) sobrinho (at) gmail (dot) com>
+     * @author xZero707 <xzero@elite7hackers.net> OOP adaptation
+     */
+    public function array_merge_recursive_distinct(array &$array1, array &$array2)
+    {
+        $merged = $array1;
+
+        foreach ($array2 as $key => &$value) {
+            if (is_array($value) && isset ($merged [$key]) && is_array($merged [$key])) {
+                $merged [$key] = $this->array_merge_recursive_distinct($merged [$key], $value);
+            } else {
+                $merged [$key] = $value;
+            }
+        }
+
+        return $merged;
+    }
+}

--- a/src/Locales/en_GB.php
+++ b/src/Locales/en_GB.php
@@ -1,52 +1,80 @@
 <?php
 
-// locale: great britain english (en-gb)
-// author: Chris Gedrim https://github.com/chrisgedrim
+namespace Moment\Locales;
 
-return array(
-    "months"        => explode('_', 'January_February_March_April_May_June_July_August_September_October_November_December'),
-    "monthsNominative"        => explode('_', 'January_February_March_April_May_June_July_August_September_October_November_December'),
-    "monthsShort"   => explode('_', 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'),
-    "weekdays"      => explode('_', 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'),
-    "weekdaysShort" => explode('_', 'Mon_Tue_Wed_Thu_Fri_Sat_Sun'),
-    "calendar"      => array(
-        "sameDay"  => '[Today]',
-        "nextDay"  => '[Tomorrow]',
-        "lastDay"  => '[Yesterday]',
-        "lastWeek" => '[Last] l',
-        "sameElse" => 'l',
-        "withTime" => '[at] H:i',
-        "default"  => 'd/m/Y',
-    ),
-    "relativeTime"  => array(
-        "future" => 'in %s',
-        "past"   => '%s ago',
-        "s"      => 'a few seconds',
-        "m"      => 'a minute',
-        "mm"     => '%d minutes',
-        "h"      => 'an hour',
-        "hh"     => '%d hours',
-        "d"      => 'a day',
-        "dd"     => '%d days',
-        "M"      => 'a month',
-        "MM"     => '%d months',
-        "y"      => 'a year',
-        "yy"     => '%d years',
-    ),
-    "ordinal"       => function ($number)
+use Moment\Provider\LocaleProvider;
+
+/**
+ * Class en_GB
+ * @package Moment\Locales
+ *
+ * Great britain english (en-gb) locale
+ *
+ * @author Chris Gedrim <https://github.com/chrisgedrim>
+ */
+class en_GB extends LocaleProvider
+{
+    /**
+     * en_GB constructor.
+     *
+     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     */
+    public function __construct(array $definitions = null)
     {
-        $n = $number % 100;
-        $ends = array('th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th');
+        parent::__construct('en_GB');
 
-        if ($n >= 11 && $n <= 13)
-        {
-            return $number . '[th]';
+        $this->setDefinitions([
+            "months"           => explode('_',
+                'January_February_March_April_May_June_July_August_September_October_November_December'),
+            "monthsNominative" => explode('_',
+                'January_February_March_April_May_June_July_August_September_October_November_December'),
+            "monthsShort"      => explode('_', 'Jan_Feb_Mar_Apr_May_Jun_Jul_Aug_Sep_Oct_Nov_Dec'),
+            "weekdays"         => explode('_', 'Monday_Tuesday_Wednesday_Thursday_Friday_Saturday_Sunday'),
+            "weekdaysShort"    => explode('_', 'Mon_Tue_Wed_Thu_Fri_Sat_Sun'),
+            "calendar"         => [
+                "sameDay"  => '[Today]',
+                "nextDay"  => '[Tomorrow]',
+                "lastDay"  => '[Yesterday]',
+                "lastWeek" => '[Last] l',
+                "sameElse" => 'l',
+                "withTime" => '[at] H:i',
+                "default"  => 'd/m/Y',
+            ],
+            "relativeTime"     => [
+                "future" => 'in %s',
+                "past"   => '%s ago',
+                "s"      => 'a few seconds',
+                "m"      => 'a minute',
+                "mm"     => '%d minutes',
+                "h"      => 'an hour',
+                "hh"     => '%d hours',
+                "d"      => 'a day',
+                "dd"     => '%d days',
+                "M"      => 'a month',
+                "MM"     => '%d months',
+                "y"      => 'a year',
+                "yy"     => '%d years',
+            ],
+            "ordinal"          => function ($number) {
+                $n    = $number % 100;
+                $ends = ['th', 'st', 'nd', 'rd', 'th', 'th', 'th', 'th', 'th', 'th'];
+
+                if ($n >= 11 && $n <= 13) {
+                    return $number . '[th]';
+                }
+
+                return $number . '[' . $ends[$number % 10] . ']';
+            },
+            "week"             => [
+                "dow" => 1, // Monday is the first day of the week.
+                "doy" => 4  // The week that contains Jan 4th is the first week of the year.
+            ],
+        ]);
+
+
+        // Apply $definitions if array is supplied
+        if ($definitions !== null) {
+            $this->alterDefinitions($definitions);
         }
-
-        return $number . '[' . $ends[$number % 10] . ']';
-    },
-    "week"          => array(
-        "dow" => 1, // Monday is the first day of the week.
-        "doy" => 4  // The week that contains Jan 4th is the first week of the year.
-    ),
-);
+    }
+}

--- a/src/Locales/en_GB.php
+++ b/src/Locales/en_GB.php
@@ -15,14 +15,10 @@ use Moment\Provider\LocaleProvider;
 class en_GB extends LocaleProvider
 {
     /**
-     * en_GB constructor.
-     *
-     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     * {@inheritdoc}
      */
-    public function __construct(array $definitions = null)
+    protected function defineLocale(array $definitions = null)
     {
-        parent::__construct('en_GB');
-
         $this->setDefinitions([
             "months"           => explode('_',
                 'January_February_March_April_May_June_July_August_September_October_November_December'),

--- a/src/Locales/en_US.php
+++ b/src/Locales/en_US.php
@@ -1,10 +1,34 @@
 <?php
 
-// locale: american english (en_US)
+namespace Moment\Locales;
 
-$locale = require __DIR__ . '/en_GB.php';
-$locale['calendar']['withTime'] = '[at] h:i A';
-$locale['calendar']['default'] = 'm/d/Y';
-$locale['week']['dow'] = 7;
+/**
+ * Class en_US
+ * @package Moment\Locales
+ *
+ * American english (en_US) locale
+ *
+ * @author Unknown <--- unknown --->
+ */
+class en_US extends en_GB
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function defineLocale(array $definitions = null)
+    {
+        parent::defineLocale([
+            'calendar' => [
+                'withTime' => '[at] h:i A',
+                'default'  => 'm/d/Y'
+            ],
+            'week'     => [
+                'dow' => 7
+            ]
+        ]);
 
-return $locale;
+        if ($definitions !== null) {
+            $this->alterDefinitions($definitions);
+        }
+    }
+}

--- a/src/Locales/fr_FR.php
+++ b/src/Locales/fr_FR.php
@@ -15,14 +15,10 @@ use Moment\Provider\LocaleProvider;
 class fr_FR extends LocaleProvider
 {
     /**
-     * fr_FR constructor.
-     *
-     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     * {@inheritdoc}
      */
-    public function __construct(array $definitions = null)
+    protected function defineLocale(array $definitions = null)
     {
-        parent::__construct('fr_FR');
-
         $this->setDefinitions([
             "months"        => explode('_',
                 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'),

--- a/src/Locales/fr_FR.php
+++ b/src/Locales/fr_FR.php
@@ -1,54 +1,83 @@
 <?php
 
-// locale: french (fr)
-// author: John Fischer https://github.com/jfroffice
+namespace Moment\Locales;
 
-return array(
-    "months"        => explode('_', 'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'),
-    "monthsShort"   => explode('_', 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'),
-    "weekdays"      => explode('_', 'lundi_mardi_mercredi_jeudi_vendredi_samedi_dimanche'),
-    "weekdaysShort" => explode('_', 'lun._mar._mer._jeu._ven._sam._dim.'),
-    "calendar"      => array(
-        "sameDay"  => '[Aujourd\'hui]',
-        "nextDay"  => '[Demain]',
-        "lastDay"  => '[Hier]',
-        "lastWeek" => 'l [dernier]',
-        "sameElse" => 'l',
-        "withTime" => '[à] H:i',
-        "default"  => 'd/m/Y',
-    ),
-    "relativeTime"  => array(
-        "future" => 'dans %s',
-        "past"   => 'il y a %s',
-        "s"      => 'quelques secondes',
-        "m"      => 'une minute',
-        "mm"     => '%d minutes',
-        "h"      => 'une heure',
-        "hh"     => '%d heures',
-        "d"      => 'un jour',
-        "dd"     => '%d jours',
-        "M"      => 'un mois',
-        "MM"     => '%d mois',
-        "y"      => 'un an',
-        "yy"     => '%d ans',
-    ),
-    "ordinal"       => function ($number)
+use Moment\Provider\LocaleProvider;
+
+/**
+ * Class fr_FR
+ * @package Moment\Locales
+ *
+ * French locale
+ *
+ * @author John Fischer <https://github.com/jfroffice>
+ */
+class fr_FR extends LocaleProvider
+{
+    /**
+     * fr_FR constructor.
+     *
+     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     */
+    public function __construct(array $definitions = null)
     {
-        return $number . ($number === 1 ? '[er]' : '');
-    },
-    "week"          => array(
-        "dow" => 1, // Monday is the first day of the week.
-        "doy" => 4  // The week that contains Jan 4th is the first week of the year.
-    ),
-    "customFormats" => array(
-        "LT"   => "G:i", // 20:30
-        "L"    => "d/m/Y", // 04/09/1986
-        "l"    => "j/n/Y", // 4/9/1986
-        "LL"   => "jS F Y", // 4 Septembre 1986
-        "ll"   => "j M Y", // 4 Sep 1986
-        "LLL"  => "jS F Y G:i", // 4 Septembre 1986 20:30
-        "lll"  => "j M Y G:i", // 4 Sep 1986 20:30
-        "LLLL" => "l, jS F Y G:i", // Jeudi, 4 Septembre 1986 20:30
-        "llll" => "D, j M Y G:i", // Jeu, 4 Sep 1986 20:30
-    ),
-);
+        parent::__construct('fr_FR');
+
+        $this->setDefinitions([
+            "months"        => explode('_',
+                'janvier_février_mars_avril_mai_juin_juillet_août_septembre_octobre_novembre_décembre'),
+            "monthsShort"   => explode('_', 'janv._févr._mars_avr._mai_juin_juil._août_sept._oct._nov._déc.'),
+            "weekdays"      => explode('_', 'lundi_mardi_mercredi_jeudi_vendredi_samedi_dimanche'),
+            "weekdaysShort" => explode('_', 'lun._mar._mer._jeu._ven._sam._dim.'),
+            "calendar"      => [
+                "sameDay"  => '[Aujourd\'hui]',
+                "nextDay"  => '[Demain]',
+                "lastDay"  => '[Hier]',
+                "lastWeek" => 'l [dernier]',
+                "sameElse" => 'l',
+                "withTime" => '[à] H:i',
+                "default"  => 'd/m/Y',
+            ],
+            "relativeTime"  => [
+                "future" => 'dans %s',
+                "past"   => 'il y a %s',
+                "s"      => 'quelques secondes',
+                "m"      => 'une minute',
+                "mm"     => '%d minutes',
+                "h"      => 'une heure',
+                "hh"     => '%d heures',
+                "d"      => 'un jour',
+                "dd"     => '%d jours',
+                "M"      => 'un mois',
+                "MM"     => '%d mois',
+                "y"      => 'un an',
+                "yy"     => '%d ans',
+            ],
+            "ordinal"       => function ($number) {
+                return $number . ($number === 1 ? '[er]' : '');
+            },
+            "week"          => [
+                "dow" => 1, // Monday is the first day of the week.
+                "doy" => 4  // The week that contains Jan 4th is the first week of the year.
+            ],
+            "customFormats" => [
+                "LT"   => "G:i", // 20:30
+                "L"    => "d/m/Y", // 04/09/1986
+                "l"    => "j/n/Y", // 4/9/1986
+                "LL"   => "jS F Y", // 4 Septembre 1986
+                "ll"   => "j M Y", // 4 Sep 1986
+                "LLL"  => "jS F Y G:i", // 4 Septembre 1986 20:30
+                "lll"  => "j M Y G:i", // 4 Sep 1986 20:30
+                "LLLL" => "l, jS F Y G:i", // Jeudi, 4 Septembre 1986 20:30
+                "llll" => "D, j M Y G:i", // Jeu, 4 Sep 1986 20:30
+            ],
+        ]);
+
+
+        // Apply $definitions if array is supplied
+        if ($definitions !== null) {
+            $this->alterDefinitions($definitions);
+        }
+    }
+}
+

--- a/src/Locales/no_NB.php
+++ b/src/Locales/no_NB.php
@@ -15,14 +15,10 @@ use Moment\Provider\LocaleProvider;
 class no_NB extends LocaleProvider
 {
     /**
-     * no_NB constructor.
-     *
-     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     * {@inheritdoc}
      */
-    public function __construct(array $definitions = null)
+    protected function defineLocale(array $definitions = null)
     {
-        parent::__construct('no_NB');
-
         $this->setDefinitions([
 
             'months'        => explode('_',

--- a/src/Locales/no_NB.php
+++ b/src/Locales/no_NB.php
@@ -2,23 +2,18 @@
 
 namespace Moment\Locales;
 
-use Moment\Helpers\ArrayHelpers;
-use Moment\Provider\LocaleProviderInterface;
+use Moment\Provider\LocaleProvider;
 
 /**
  * Class no_NB
  * @package Moment\Locales
  *
  * Norwegian locale
+ *
+ * @author xZero707 <xzero@elite7hackers.net>
  */
-class no_NB implements LocaleProviderInterface
+class no_NB extends LocaleProvider
 {
-    /** @var array */
-    private $localeDefinitions;
-
-    /** @var string */
-    private $localeName;
-
     /**
      * no_NB constructor.
      *
@@ -26,8 +21,9 @@ class no_NB implements LocaleProviderInterface
      */
     public function __construct(array $definitions = null)
     {
-        $this->localeName        = 'nb_NO';
-        $this->localeDefinitions = [
+        parent::__construct('no_NB');
+
+        $this->setDefinitions([
 
             'months'        => explode('_',
                 'Januar_Februar_Mars_April_Mai_Juni_Juli_August_September_Oktober_November_Desember'),
@@ -70,46 +66,12 @@ class no_NB implements LocaleProviderInterface
                 'doy' => 4  // The week that contains Jan 4th is the first week of the year.
             ]
 
-        ];
+        ]);
+
 
         // Apply $definitions if array is supplied
         if ($definitions !== null) {
-            $arrayHelpers            = new ArrayHelpers();
-            $this->localeDefinitions =
-                $arrayHelpers->array_merge_recursive_distinct($this->localeDefinitions, $definitions);
+            $this->alterDefinitions($definitions);
         }
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return $this->localeName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinition($name, callable $callback = null)
-    {
-        if (isset($this->localeDefinitions[$name])) {
-            $definition = $this->localeDefinitions[$name];
-
-            return ($callback !== null) ? $callback($definition) : $definition;
-        }
-
-        return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDefinitions(callable $callback = null)
-    {
-        return ($callback !== null) ? $callback($this->localeDefinitions) : $this->localeDefinitions;
     }
 }
-
-// locale: Swedish (se-SV)
-// author: Martin Trobäck https://github.com/lekoaf

--- a/src/Locales/no_NB.php
+++ b/src/Locales/no_NB.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Moment\Locales;
+
+use Moment\Helpers\ArrayHelpers;
+use Moment\Provider\LocaleProviderInterface;
+
+/**
+ * Class no_NB
+ * @package Moment\Locales
+ *
+ * Norwegian locale
+ */
+class no_NB implements LocaleProviderInterface
+{
+    /** @var array */
+    private $localeDefinitions;
+
+    /** @var string */
+    private $localeName;
+
+    /**
+     * no_NB constructor.
+     *
+     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     */
+    public function __construct(array $definitions = null)
+    {
+        $this->localeName        = 'nb_NO';
+        $this->localeDefinitions = [
+
+            'months'        => explode('_',
+                'Januar_Februar_Mars_April_Mai_Juni_Juli_August_September_Oktober_November_Desember'),
+            'monthsShort'   => explode('_', 'Jan_Feb_Mar_Apr_Mai_Jun_Jul_Aug_Sep_Okt_Nov_Dec'),
+            'weekdays'      => explode('_', 'Måndag_Tirsdag_Onsdag_Torsdag_Fredag_Lørdag_Søndag'),
+            'weekdaysShort' => explode('_', 'Mån_Tir_Ons_Tor_Fre_Lør_Søn'),
+
+            'calendar' => [
+                'sameDay'  => '[Idag]',
+                'nextDay'  => '[Imorgen]',
+                'lastDay'  => '[Igår]',
+                'lastWeek' => '[Forrige] l',
+                'sameElse' => 'l',
+                'withTime' => '[kl] H:i',
+                'default'  => 'Y/m/d',
+            ],
+
+            'relativeTime' => [
+                'future' => 'om %s',
+                'past'   => '%s sent',
+                's'      => 'få sekunder',
+                'm'      => 'en minut',
+                'mm'     => '%d minuter',
+                'h'      => 'en timme',
+                'hh'     => '%d timmar',
+                'd'      => 'en dag',
+                'dd'     => '%d dagar',
+                'M'      => 'en månad',
+                'MM'     => '%d månader',
+                'y'      => 'ett år',
+                'yy'     => '%d år',
+            ],
+
+            'ordinal' => function ($number) {
+                return $number;
+            },
+
+            'week' => [
+                'dow' => 1, // Monday is the first day of the week.
+                'doy' => 4  // The week that contains Jan 4th is the first week of the year.
+            ]
+
+        ];
+
+        // Apply $definitions if array is supplied
+        if ($definitions !== null) {
+            $arrayHelpers            = new ArrayHelpers();
+            $this->localeDefinitions =
+                $arrayHelpers->array_merge_recursive_distinct($this->localeDefinitions, $definitions);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->localeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition($name, callable $callback = null)
+    {
+        if (isset($this->localeDefinitions[$name])) {
+            $definition = $this->localeDefinitions[$name];
+
+            return ($callback !== null) ? $callback($definition) : $definition;
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinitions(callable $callback = null)
+    {
+        return ($callback !== null) ? $callback($this->localeDefinitions) : $this->localeDefinitions;
+    }
+}
+
+// locale: Swedish (se-SV)
+// author: Martin Trobäck https://github.com/lekoaf

--- a/src/Locales/pt_BR.php
+++ b/src/Locales/pt_BR.php
@@ -16,14 +16,10 @@ use Moment\Provider\LocaleProvider;
 class pt_BR extends LocaleProvider
 {
     /**
-     * pt_BR constructor.
-     *
-     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     * {@inheritdoc}
      */
-    public function __construct(array $definitions = null)
+    protected function defineLocale(array $definitions = null)
     {
-        parent::__construct('pt_BR');
-
         $this->setDefinitions([
             "months"        => explode('_',
                 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'),

--- a/src/Locales/pt_BR.php
+++ b/src/Locales/pt_BR.php
@@ -1,45 +1,75 @@
 <?php
 
-// locale: portuguese (pt-br)
-// author: Jefferson Santos https://github.com/jefflssantos
+namespace Moment\Locales;
 
 use Moment\Moment;
+use Moment\Provider\LocaleProvider;
 
-return array(
-    "months"        => explode('_', 'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'),
-    "monthsShort"   => explode('_', 'jan._fev._mar._abr._mai._jun._jul._ago._set._out._nov._dez.'),
-    "weekdays"      => explode('_', 'segunda_terça_quarta_quinta_sexta_sábado_domingo'),
-    "weekdaysShort" => explode('_', 'seg._ter._qua._qui._sex._sáb._dom.'),
-    "calendar"      => array(
-        "sameDay"  => '[hoje]',
-        "nextDay"  => '[amanhã]',
-        "lastDay"  => '[ontem]',
-        "lastWeek" => '[útimo] l',
-        "sameElse" => 'eu',
-        "withTime" => function (Moment $moment) { return '[à' . ($moment->getHour() !== 1 ? 's' : null) . '] H:i'; },
-        "default"  => 'd/m/Y',
-    ),
-    "relativeTime"  => array(
-        "future" => 'em %s',
-        "past"   => 'há %s',
-        "s"      => 'alguns segundos',
-        "m"      => 'um minuto',
-        "mm"     => '%d minutos',
-        "h"      => 'uma hora',
-        "hh"     => '%d horas',
-        "d"      => 'um dia',
-        "dd"     => '%d dias',
-        "M"      => 'um mês',
-        "MM"     => '%d meses',
-        "y"      => 'um ano',
-        "yy"     => '%d anos',
-    ),
-    "ordinal"       => function ($number)
+/**
+ * Class pt_BR
+ * @package Moment\Locales
+ *
+ * Portuguese (pt-br) locale
+ *
+ * @author Jefferson Santos <https://github.com/jefflssantos>
+ */
+class pt_BR extends LocaleProvider
+{
+    /**
+     * pt_BR constructor.
+     *
+     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     */
+    public function __construct(array $definitions = null)
     {
-        return $number . 'º';
-    },
-    "week"          => array(
-        "dow" => 1, // Monday is the first day of the week.
-        "doy" => 4  // The week that contains Jan 4th is the first week of the year.
-    ),
-);
+        parent::__construct('pt_BR');
+
+        $this->setDefinitions([
+            "months"        => explode('_',
+                'janeiro_fevereiro_março_abril_maio_junho_julho_agosto_setembro_outubro_novembro_dezembro'),
+            "monthsShort"   => explode('_', 'jan._fev._mar._abr._mai._jun._jul._ago._set._out._nov._dez.'),
+            "weekdays"      => explode('_', 'segunda_terça_quarta_quinta_sexta_sábado_domingo'),
+            "weekdaysShort" => explode('_', 'seg._ter._qua._qui._sex._sáb._dom.'),
+            "calendar"      => [
+                "sameDay"  => '[hoje]',
+                "nextDay"  => '[amanhã]',
+                "lastDay"  => '[ontem]',
+                "lastWeek" => '[útimo] l',
+                "sameElse" => 'eu',
+                "withTime" => function (Moment $moment) {
+                    return '[à' . ($moment->getHour() !== 1 ? 's' : null) . '] H:i';
+                },
+                "default"  => 'd/m/Y',
+            ],
+            "relativeTime"  => [
+                "future" => 'em %s',
+                "past"   => 'há %s',
+                "s"      => 'alguns segundos',
+                "m"      => 'um minuto',
+                "mm"     => '%d minutos',
+                "h"      => 'uma hora',
+                "hh"     => '%d horas',
+                "d"      => 'um dia',
+                "dd"     => '%d dias',
+                "M"      => 'um mês',
+                "MM"     => '%d meses',
+                "y"      => 'um ano',
+                "yy"     => '%d anos',
+            ],
+            "ordinal"       => function ($number) {
+                return $number . 'º';
+            },
+            "week"          => [
+                "dow" => 1, // Monday is the first day of the week.
+                "doy" => 4  // The week that contains Jan 4th is the first week of the year.
+            ],
+        ]);
+
+
+        // Apply $definitions if array is supplied
+        if ($definitions !== null) {
+            $this->alterDefinitions($definitions);
+        }
+    }
+}
+

--- a/src/Locales/pt_PT.php
+++ b/src/Locales/pt_PT.php
@@ -1,4 +1,15 @@
 <?php
-// locale: native portuguese (pt_PT)
 
-return require __DIR__ . '/pt_BR.php';
+namespace Moment\Locales;
+
+/**
+ * Class pt_PT
+ * @package Moment\Locales
+ *
+ * Native portuguese (en-gb) locale
+ *
+ * @author João Ramos <https://github.com/joaomramos>
+ */
+class pt_PT extends pt_BR
+{
+}

--- a/src/Locales/pt_PT.php
+++ b/src/Locales/pt_PT.php
@@ -6,7 +6,7 @@ namespace Moment\Locales;
  * Class pt_PT
  * @package Moment\Locales
  *
- * Native portuguese (en-gb) locale
+ * Native portuguese (pt-PT) locale
  *
  * @author João Ramos <https://github.com/joaomramos>
  */

--- a/src/Locales/se_SV.php
+++ b/src/Locales/se_SV.php
@@ -1,42 +1,71 @@
 <?php
 
-// locale: Swedish (se-SV)
-// author: Martin Trobäck https://github.com/lekoaf
+namespace Moment\Locales;
 
-return array(
-    "months"        => explode('_', 'Januari_Februari_Mars_April_Maj_Juni_Juli_Augusti_September_Oktober_November_December'),
-    "monthsShort"   => explode('_', 'Jan_Feb_Mar_Apr_Maj_Jun_Jul_Aug_Sep_Okt_Nov_Dec'),
-    "weekdays"      => explode('_', 'Måndag_Tisdag_Onsdag_Torsdag_Fredag_Lördag_Söndag'),
-    "weekdaysShort" => explode('_', 'Mån_Tis_Ons_Tor_Fre_Lör_Sön'),
-    "calendar"      => array(
-        "sameDay"  => '[Idag]',
-        "nextDay"  => '[Imorgon]',
-        "lastDay"  => '[Igår]',
-        "lastWeek" => '[Förra] l',
-        "sameElse" => 'l',
-        "withTime" => '[kl] H:i',
-        "default"  => 'Y/m/d',
-    ),
-    "relativeTime"  => array(
-        "future" => 'om %s',
-        "past"   => '%s sen',
-        "s"      => 'några sekunder',
-        "m"      => 'en minut',
-        "mm"     => '%d minuter',
-        "h"      => 'en timme',
-        "hh"     => '%d timmar',
-        "d"      => 'en dag',
-        "dd"     => '%d dagar',
-        "M"      => 'en månad',
-        "MM"     => '%d månader',
-        "y"      => 'ett år',
-        "yy"     => '%d år',
-    ),
-    "ordinal"       => function ($number) {
-        return $number;
-    },
-    "week"          => array(
-        "dow" => 1, // Monday is the first day of the week.
-        "doy" => 4  // The week that contains Jan 4th is the first week of the year.
-    ),
-);
+use Moment\Provider\LocaleProvider;
+
+/**
+ * Class se_SV
+ * @package Moment\Locales
+ *
+ * Swedish locale
+ *
+ * @author Martin Trobäck <https://github.com/lekoaf>
+ */
+class se_SV extends LocaleProvider
+{
+    /**
+     * se_SV constructor.
+     *
+     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     */
+    public function __construct(array $definitions = null)
+    {
+        parent::__construct('se_SV');
+
+        $this->setDefinitions([
+            "months"        => explode('_',
+                'Januari_Februari_Mars_April_Maj_Juni_Juli_Augusti_September_Oktober_November_December'),
+            "monthsShort"   => explode('_', 'Jan_Feb_Mar_Apr_Maj_Jun_Jul_Aug_Sep_Okt_Nov_Dec'),
+            "weekdays"      => explode('_', 'Måndag_Tisdag_Onsdag_Torsdag_Fredag_Lördag_Söndag'),
+            "weekdaysShort" => explode('_', 'Mån_Tis_Ons_Tor_Fre_Lör_Sön'),
+            "calendar"      => [
+                "sameDay"  => '[Idag]',
+                "nextDay"  => '[Imorgon]',
+                "lastDay"  => '[Igår]',
+                "lastWeek" => '[Förra] l',
+                "sameElse" => 'l',
+                "withTime" => '[kl] H:i',
+                "default"  => 'Y/m/d',
+            ],
+            "relativeTime"  => [
+                "future" => 'om %s',
+                "past"   => '%s sen',
+                "s"      => 'några sekunder',
+                "m"      => 'en minut',
+                "mm"     => '%d minuter',
+                "h"      => 'en timme',
+                "hh"     => '%d timmar',
+                "d"      => 'en dag',
+                "dd"     => '%d dagar',
+                "M"      => 'en månad',
+                "MM"     => '%d månader',
+                "y"      => 'ett år',
+                "yy"     => '%d år',
+            ],
+            "ordinal"       => function ($number) {
+                return $number;
+            },
+            "week"          => [
+                "dow" => 1, // Monday is the first day of the week.
+                "doy" => 4  // The week that contains Jan 4th is the first week of the year.
+            ],
+        ]);
+
+
+        // Apply $definitions if array is supplied
+        if ($definitions !== null) {
+            $this->alterDefinitions($definitions);
+        }
+    }
+}

--- a/src/Locales/se_SV.php
+++ b/src/Locales/se_SV.php
@@ -15,14 +15,10 @@ use Moment\Provider\LocaleProvider;
 class se_SV extends LocaleProvider
 {
     /**
-     * se_SV constructor.
-     *
-     * @param array|null $definitions - Allows overriding or adding new definitions on the fly
+     * {@inheritdoc}
      */
-    public function __construct(array $definitions = null)
+    protected function defineLocale(array $definitions = null)
     {
-        parent::__construct('se_SV');
-
         $this->setDefinitions([
             "months"        => explode('_',
                 'Januari_Februari_Mars_April_Maj_Juni_Juli_Augusti_September_Oktober_November_December'),

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -75,7 +75,7 @@ class Moment extends \DateTime
         MomentLocale::setMoment($this);
 
         // load locale content
-        MomentLocale::loadLocaleContent();
+        MomentLocale::loadLocaleContent(MomentLocale::LOAD_CAREFULLY);
 
         // initialize DateTime
         $this->resetDateTime($dateTime, $timezone);

--- a/src/MomentLocale.php
+++ b/src/MomentLocale.php
@@ -11,6 +11,8 @@ use Moment\Provider\LocaleProviderInterface;
  */
 class MomentLocale
 {
+    const LOAD_CAREFULLY = 11;
+
     /**
      * @var Moment
      */
@@ -57,8 +59,11 @@ class MomentLocale
      * @return void
      * @throws MomentException
      */
-    public static function loadLocaleContent()
+    public static function loadLocaleContent($loadCarefully = 0)
     {
+        if(($loadCarefully === self::LOAD_CAREFULLY) && !empty(self::$localeContent)) {
+            return;
+        }
         $pathFile = __DIR__ . '/Locales/' . self::$locale . '.php';
 
         if (file_exists($pathFile) === false)

--- a/src/MomentLocale.php
+++ b/src/MomentLocale.php
@@ -2,6 +2,8 @@
 
 namespace Moment;
 
+use Moment\Provider\LocaleProviderInterface;
+
 /**
  * MomentLocale
  * @package Moment
@@ -33,13 +35,20 @@ class MomentLocale
     }
 
     /**
-     * @param $locale
+     * @param string|LocaleProviderInterface $locale
      *
      * @return void
      * @throws MomentException
      */
     public static function setLocale($locale)
     {
+        if ($locale instanceof LocaleProviderInterface) {
+            self::$locale        = $locale->getName();
+            self::$localeContent = $locale->getDefinitions();
+
+            return;
+        }
+
         self::$locale = $locale;
         self::loadLocaleContent();
     }

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -2,6 +2,7 @@
 
 namespace Moment\Provider;
 
+use ReflectionClass;
 use Moment\Helpers\ArrayHelpers;
 
 /**
@@ -18,22 +19,17 @@ abstract class LocaleProvider implements LocaleProviderInterface
     /** @var string */
     protected $localeName;
 
-    public function __construct($name)
+    /**
+     * LocaleProvider constructor.
+     *
+     * @param array|null $definitions
+     */
+    final public function __construct(array $definitions = null)
     {
-        $this->localeName        = $name;
+        $this->localeName        = (new ReflectionClass(static::class))->getShortName();
         $this->localeDefinitions = [];
-    }
 
-    protected function setDefinitions(array $definitions)
-    {
-        $this->localeDefinitions = $definitions;
-    }
-
-    protected function alterDefinitions(array $definitionsSet)
-    {
-        $arrayHelpers            = new ArrayHelpers();
-        $this->localeDefinitions =
-            $arrayHelpers->array_merge_recursive_distinct($this->localeDefinitions, $definitionsSet);
+        $this->defineLocale($definitions);
     }
 
     /**
@@ -66,4 +62,34 @@ abstract class LocaleProvider implements LocaleProviderInterface
         return ($callback !== null) ? $callback($this->localeDefinitions) : $this->localeDefinitions;
     }
 
+    /**
+     * Declares definitions - by replacing whole array with a fresh one
+     *
+     * @param array $definitions
+     */
+    protected function setDefinitions(array $definitions)
+    {
+        $this->localeDefinitions = $definitions;
+    }
+
+    /**
+     * Allows overriding definitions
+     *
+     * @param array $definitionsSet
+     */
+    protected function alterDefinitions(array $definitionsSet)
+    {
+        $arrayHelpers            = new ArrayHelpers();
+        $this->localeDefinitions =
+            $arrayHelpers->array_merge_recursive_distinct($this->localeDefinitions, $definitionsSet);
+    }
+
+    /**
+     * This is setup stub, kind of constructor. Runs every time locale is initialized
+     *
+     * @param array|null $definitions
+     *
+     * @return void
+     */
+    abstract protected function defineLocale(array $definitions = null);
 }

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Moment\Provider;
+
+use Moment\Helpers\ArrayHelpers;
+
+/**
+ * Class LocaleProvider
+ * @package Moment\Provider
+ *
+ * @author xZero707 <xzero@elite7hackers.net>
+ */
+abstract class LocaleProvider implements LocaleProviderInterface
+{
+    /** @var array */
+    protected $localeDefinitions;
+
+    /** @var string */
+    protected $localeName;
+
+    public function __construct($name)
+    {
+        $this->localeName        = $name;
+        $this->localeDefinitions = [];
+    }
+
+    protected function setDefinitions(array $definitions)
+    {
+        $this->localeDefinitions = $definitions;
+    }
+
+    protected function alterDefinitions(array $definitionsSet)
+    {
+        $arrayHelpers            = new ArrayHelpers();
+        $this->localeDefinitions =
+            $arrayHelpers->array_merge_recursive_distinct($this->localeDefinitions, $definitionsSet);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->localeName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinition($name, callable $callback = null)
+    {
+        if (isset($this->localeDefinitions[$name])) {
+            $definition = $this->localeDefinitions[$name];
+
+            return ($callback !== null) ? $callback($definition) : $definition;
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefinitions(callable $callback = null)
+    {
+        return ($callback !== null) ? $callback($this->localeDefinitions) : $this->localeDefinitions;
+    }
+
+}

--- a/src/Provider/LocaleProvider.php
+++ b/src/Provider/LocaleProvider.php
@@ -63,21 +63,17 @@ abstract class LocaleProvider implements LocaleProviderInterface
     }
 
     /**
-     * Declares definitions - by replacing whole array with a fresh one
-     *
-     * @param array $definitions
+     * {@inheritdoc}
      */
-    protected function setDefinitions(array $definitions)
+    public function setDefinitions(array $definitions)
     {
         $this->localeDefinitions = $definitions;
     }
 
     /**
-     * Allows overriding definitions
-     *
-     * @param array $definitionsSet
+     * {@inheritdoc}
      */
-    protected function alterDefinitions(array $definitionsSet)
+    public function alterDefinitions(array $definitionsSet)
     {
         $arrayHelpers            = new ArrayHelpers();
         $this->localeDefinitions =

--- a/src/Provider/LocaleProviderInterface.php
+++ b/src/Provider/LocaleProviderInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Moment\Provider;
+
+/**
+ * Interface LocaleProviderInterface
+ * @package Moment\Provider
+ *
+ * @author xZero707 <xzero@elite7hackers.net>
+ *
+ * Provider interface which MUST be implemented by locale
+ */
+interface LocaleProviderInterface
+{
+
+    /**
+     * Get locale name
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Get specific definition
+     *
+     * eg. getDefinition('monthsNominative')
+     *
+     * @param string $name
+     * @param callable|null $callback
+     *
+     * @return mixed
+     */
+    public function getDefinition($name, callable $callback = null);
+
+    /**
+     * Get all locale definitions
+     *
+     * @param callable|null $callback
+     *
+     * @return array
+     */
+    public function getDefinitions(callable $callback = null);
+}

--- a/src/Provider/LocaleProviderInterface.php
+++ b/src/Provider/LocaleProviderInterface.php
@@ -40,4 +40,18 @@ interface LocaleProviderInterface
      * @return array
      */
     public function getDefinitions(callable $callback = null);
+
+    /**
+     * Declares definitions - by replacing whole array with a fresh one
+     *
+     * @param array $definitions
+     */
+    public function setDefinitions(array $definitions);
+
+    /**
+     * Allows overriding definitions
+     *
+     * @param array $definitionsSet
+     */
+    public function alterDefinitions(array $definitionsSet);
 }


### PR DESCRIPTION
### 2.0.0
 - fixed:
    - en_GB OOP
    - sv_SE OOP
    - pt_BR OOP
    - pt_PT OOP
    - fr_FR
 - other:
    - Locales uses new array syntax, therefore killing < PHP5.4 support (PHP5.3)   

### 1.27.0
 - added:
    - OOP way of setting locale (dependency injection)
      - Allows shipping locales in separate composer modules
      - Allows overriding definitions of locale on the fly
    - Norwegian locale (no_NB)

### TODO:
 - tests
 - fix tests so compatible with new system
 - convert rest of locales
 - move rest of locales to separate repos (composer managed)
 - make sure that backward compatibility is not broken