### PR TITLE
Moment::setTimeZone is incompatible with DateTime::setTimeZome

### DIFF
--- a/src/Moment.php
+++ b/src/Moment.php
@@ -144,7 +144,7 @@ class Moment extends \DateTime
     }
 
     /**
-     * @param string $timezone
+     * @param string|\DateTimeZone $timezone
      *
      * @return \DateTime|Moment
      */
@@ -153,6 +153,11 @@ class Moment extends \DateTime
         if ($this->immutableMode)
         {
             return $this->implicitCloning(__FUNCTION__, func_get_args());
+        }
+
+        if ($timezone instanceof \DateTimeZone)
+        {
+            $timezone = $timezone->getName();
         }
 
         $this->setTimezoneString($timezone);


### PR DESCRIPTION
[DateTime::setTimeZone takes a DateTimeZone object as a parameter](http://php.net/manual/en/datetime.settimezone.php). Moment only takes a string, breaking compatibility when trying to replace use of DateTime with Moment.