### PR TITLE
Implements the LTS Moment.js localized format.

### DIFF
--- a/src/CustomFormats/MomentJs.php
+++ b/src/CustomFormats/MomentJs.php
@@ -61,6 +61,7 @@ class MomentJs implements FormatsInterface
         "Z"       => "P", // -07:00 -06:00 ... +06:00 +07:00
         "ZZ"      => "O", // -0700 -0600 ... +0600 +0700
         "X"       => "U", // 1360013296
+        "LTS"     => "g:i:s A", // 8:30:15 PM
         "LT"      => "g:i A", // 8:30 PM
         "L"       => "m/d/Y", // 09/04/1986
         "l"       => "n/j/Y", // 9/4/1986
@@ -112,7 +113,7 @@ class MomentJs implements FormatsInterface
         $tokens = $this->getTokens();
 
         // find all tokens from string, using regular expression
-        $regExp = "/(\[[^\[]*\])|(\\\\)?(LT|LL?L?L?|l{1,4}|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|.)/";
+        $regExp = "/(\[[^\[]*\])|(\\\\)?(LTS?|LL?L?L?|l{1,4}|Mo|MM?M?M?|Do|DDDo|DD?D?D?|ddd?d?|do?|w[o|w]?|W[o|W]?|YYYYY|YYYY|YY|gg(ggg?)?|GG(GGG?)?|e|E|a|A|hh?|HH?|mm?|ss?|SS?S?|X|zz?|ZZ?|.)/";
         $matches = array();
         preg_match_all($regExp, $format, $matches);
 

--- a/src/Locales/nl_NL.php
+++ b/src/Locales/nl_NL.php
@@ -41,6 +41,7 @@ return array(
         "doy" => 4  // The week that contains Jan 4th is the first week of the year.
     ),
     "customFormats" => array(
+        "LTS"  => "G:i:s", // 20:30:15
         "LT"   => "G:i", // 20:30
         "L"    => "d/m/Y", // 04/09/1986
         "l"    => "j/n/Y", // 4/9/1986


### PR DESCRIPTION
The `LTS` format (local time with seconds) was added to Moment.js in version 2.8.4. This also adds it to Moment.php's `Moment\CustomFormats\MomentJS` custom format class as well as to its `nl_NL` locale.

See:
- Commit that added it to Moment.js: https://github.com/moment/moment/commit/14f66816c9a88f1c7b387b53ecab92c2ad3d138f
- Moment.js documentation: http://momentjs.com/docs/#/displaying/format/