### PR TITLE
Fix grammar context of Latvian locale

### DIFF
--- a/src/Locales/lv_LV.php
+++ b/src/Locales/lv_LV.php
@@ -6,7 +6,7 @@
 return array(
     'months'  => explode(
         '_',
-        'Janvārī_Februāra_Marta_Aprīļa_Maija_Jūnija_Jūlija_Augustā_Septembrī_Oktobra_Novembra_Decembra'
+        'Janvārī_Februārī_Martā_Aprīlī_Maijā_Jūnijā_Jūlijā_Augustā_Septembrī_Oktobrī_Novembrī_Decembrī'
     ),
     'monthsNominative' => explode(
         '_',
@@ -14,7 +14,7 @@ return array(
     ),
     'monthsShort'  => explode(
         '_',
-        'Jan_Feb_Mar_Apr_Maijs_Jūnijs_Jūlijs_Aug_Sept_Okt_Nov_Dec'
+        'Janv_Febr_Mar_Apr_Maijs_Jūn_Jūl_Aug_Sept_Okt_Nov_Dec'
     ),
     'weekdays'  => explode(
         '_',
@@ -23,8 +23,8 @@ return array(
     'weekdaysShort'    => explode('_', 'Pr_Ot_Tr_Ce_Pk_Se_Sv'),
     'calendar'         => array(
         'sameDay'  => '[Šodien]',
-        'nextDay'  => '[Rīt]',
-        'lastDay'  => '[Vakar]',
+        'nextDay'  => '[Rītdien]',
+        'lastDay'  => '[Vakardien]',
         'lastWeek' => '[Pagājušā] l',
         'sameElse' => 'l',
         'withTime' => '[plkst.] H:i',
@@ -32,16 +32,16 @@ return array(
     ),
     'relativeTime'  => array(
         'future' => 'pēc %s',
-        'past'   => '%s atpakaļ',
+        'past'   => 'pirms %s',
         's'      => 'dažām sekundēm',
-        'm'      => 'minūte',
-        'mm'     => '%d minūtes',
-        'h'      => 'stunda',
-        'hh'     => '%d stundas',
-        'd'      => 'diena',
-        'dd'     => '%d dienas',
-        'M'      => 'mēnesis',
-        'MM'     => '%d mēneši',
+        'm'      => 'minūtes',
+        'mm'     => '%d minūtēm',
+        'h'      => 'stundas',
+        'hh'     => '%d stundām',
+        'd'      => 'dienas',
+        'dd'     => '%d dienām',
+        'M'      => 'mēneša',
+        'MM'     => '%d mēnešiem',
         'y'      => 'gada',
         'yy'     => '%d gadiem',
     ),

--- a/tests/unit/Moment/MomentLatvianLocaleTest.php
+++ b/tests/unit/Moment/MomentLatvianLocaleTest.php
@@ -51,18 +51,18 @@ class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
         $moment = new Moment($startingDate);
 
         $months = array(
-            '01' => array('Jan', 'Janvāris', 'Janvārī'),
-            '02' => array('Feb', 'Februāris', 'Februāra'),
-            '03' => array('Mar', 'Marts', 'Marta'),
-            '04' => array('Apr', 'Aprīlis', 'Aprīļa'),
-            '05' => array('Maijs', 'Maijs', 'Maija'),
-            '06' => array('Jūnijs', 'Jūnijs', 'Jūnija'),
-            '07' => array('Jūlijs', 'Jūlijs', 'Jūlija'),
+            '01' => array('Janv', 'Janvāris', 'Janvārī'),
+            '02' => array('Febr', 'Februāris', 'Februārī'),
+            '03' => array('Mar', 'Marts', 'Martā'),
+            '04' => array('Apr', 'Aprīlis', 'Aprīlī'),
+            '05' => array('Maijs', 'Maijs', 'Maijā'),
+            '06' => array('Jūn', 'Jūnijs', 'Jūnijā'),
+            '07' => array('Jūl', 'Jūlijs', 'Jūlijā'),
             '08' => array('Aug', 'Augusts', 'Augustā'),
             '09' => array('Sept', 'Septembris', 'Septembrī'),
-            '10' => array('Okt', 'Oktobris', 'Oktobra'),
-            '11' => array('Nov', 'Novembris', 'Novembra'),
-            '12' => array('Dec', 'Decembris', 'Decembra'),
+            '10' => array('Okt', 'Oktobris', 'Oktobrī'),
+            '11' => array('Nov', 'Novembris', 'Novembrī'),
+            '12' => array('Dec', 'Decembris', 'Decembrī'),
         );
         $moment->format('f');
 
@@ -96,17 +96,11 @@ class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
     {
         $string = '2015-06-14 20:46:22';
         $moment = new Moment($string, 'Europe/Riga');
-        $this->assertEquals('14 Jūnija', $moment->format('j F'));
+        $this->assertEquals('14 Jūnijā', $moment->format('j F'));
 
         $string = '2015-03-08T15:14:53-0500';
         $moment = new Moment($string, 'Europe/Riga');
-        $this->assertEquals('8 Marta', $moment->format('j F'));
-    }
-
-    public function testDayMonthFormat002()
-    {
-        $moment = new Moment('2016-01-03 16:17:07', 'Europe/Riga');
-        $this->assertEquals('3 Decembra', $moment->subtractMonths()->format('j F'));
+        $this->assertEquals('8 Martā', $moment->format('j F'));
     }
 
     public function testMinutes()
@@ -114,34 +108,31 @@ class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Riga');
 
         $relative = $past->from('2016-01-03 16:34:07');
-        $this->assertEquals('17 minūtes atpakaļ', $relative->getRelative());
+        $this->assertEquals('pirms 17 minūtēm', $relative->getRelative());
     }
 
-    public function testLastWeekWeekend()
+    public function testShowRelativeCalendarDates()
     {
         $past = new Moment('2016-04-10 16:30:07');
         $this->assertEquals('Pagājušā Svētdiena plkst. 16:30', $past->calendar(true, new Moment('2016-04-12')));
 
-        $past = new Moment('2016-04-11');
-        $this->assertEquals('Pagājušā Pirmdiena', $past->calendar(false, new Moment('2016-04-17')));
+        $past = new Moment('2016-04-10');
+        $this->assertEquals('Pagājušā Svētdiena', $past->calendar(false, new Moment('2016-04-13')));
+
+        $past = new Moment('2016-04-13');
+        $this->assertEquals('Trešdiena', $past->calendar(false, new Moment('2016-04-11')));
+
+        $past = new Moment('2016-04-13');
+        $this->assertEquals('Vakardien', $past->calendar(false, new Moment('2016-04-14')));
 
         $past = new Moment('2016-04-12');
         $this->assertEquals('Šodien', $past->calendar(false, new Moment('2016-04-12')));
 
         $past = new Moment('2016-04-13');
-        $this->assertEquals('Vakar', $past->calendar(false, new Moment('2016-04-14')));
-
-        $past = new Moment('2016-04-14');
-        $this->assertEquals('Rīt', $past->calendar(false, new Moment('2016-04-13')));
+        $this->assertEquals('Rītdien', $past->calendar(false, new Moment('2016-04-12')));
 
         $past = new Moment('2116-04-15');
         $this->assertEquals('15.04.2116', $past->calendar(false, new Moment('2017-04-23')));
-
-        $past = new Moment('2016-04-16');
-        $this->assertEquals('16.04.2016', $past->calendar(false, new Moment('2017-04-17')));
-
-        $past = new Moment('2016-04-16');
-        $this->assertEquals('Pagājušā Sestdiena', $past->calendar(false, new Moment('2016-04-18')));
     }
 
     public function testFutureRelative()
@@ -149,14 +140,29 @@ class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
         $date = new Moment('2017-01-11 01:00:00');
 
         $this->assertEquals('pēc dažām sekundēm', $date->from('2017-01-11 00:59:59')->getRelative(), 'seconds');
-        $this->assertEquals('pēc 2 minūtes', $date->from('2017-01-11 00:58:00')->getRelative(), 'minutes');
-        $this->assertEquals('pēc 2 stundas', $date->from('2017-01-10 23:00:00')->getRelative(), 'hours');
-        $this->assertEquals('pēc diena', $date->from('2017-01-10 00:00:00')->getRelative(), 'days');
-        $this->assertEquals('pēc 10 dienas', $date->from('2017-01-01 00:00:00')->getRelative(), 'days');
-        $this->assertEquals('pēc mēnesis', $date->from('2016-12-11 00:00:00')->getRelative(), 'month');
-        $this->assertEquals('pēc 3 mēneši', $date->from('2016-10-11 00:00:00')->getRelative(), 'month');
+        $this->assertEquals('pēc 2 minūtēm', $date->from('2017-01-11 00:58:00')->getRelative(), 'minutes');
+        $this->assertEquals('pēc 2 stundām', $date->from('2017-01-10 23:00:00')->getRelative(), 'hours');
+        $this->assertEquals('pēc dienas', $date->from('2017-01-10 00:00:00')->getRelative(), 'days');
+        $this->assertEquals('pēc 10 dienām', $date->from('2017-01-01 00:00:00')->getRelative(), 'days');
+        $this->assertEquals('pēc mēneša', $date->from('2016-12-11 00:00:00')->getRelative(), 'month');
+        $this->assertEquals('pēc 3 mēnešiem', $date->from('2016-10-11 00:00:00')->getRelative(), 'month');
         $this->assertEquals('pēc gada', $date->from('2016-01-11 00:00:00')->getRelative(), 'year');
         $this->assertEquals('pēc 7 gadiem', $date->from('2010-01-11 00:00:00')->getRelative(), 'year');
+    }
+
+    public function testPastRelative()
+    {
+        $date = new Moment('2010-01-11 01:00:00');
+
+        $this->assertEquals('pirms dažām sekundēm', $date->from('2010-01-11 01:00:10')->getRelative(), 'seconds');
+        $this->assertEquals('pirms 2 minūtēm', $date->from('2010-01-11 01:02:00')->getRelative(), 'minutes');
+        $this->assertEquals('pirms 2 stundām', $date->from('2010-01-11 03:00:00')->getRelative(), 'hours');
+        $this->assertEquals('pirms dienas', $date->from('2010-01-12 01:00:00')->getRelative(), 'days');
+        $this->assertEquals('pirms 10 dienām', $date->from('2010-01-21 01:00:00')->getRelative(), 'days');
+        $this->assertEquals('pirms mēneša', $date->from('2010-02-11 01:00:00')->getRelative(), 'month');
+        $this->assertEquals('pirms 3 mēnešiem', $date->from('2010-04-11 01:00:00')->getRelative(), 'month');
+        $this->assertEquals('pirms gada', $date->from('2011-01-11 01:00:00')->getRelative(), 'year');
+        $this->assertEquals('pirms 5 gadiem', $date->from('2015-01-11 01:00:00')->getRelative(), 'year');
     }
 
     public function testOrdinalFormat()
@@ -164,13 +170,13 @@ class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
         $date = new Moment('2017-01-01 01:00:00', 'Europe/Riga');
         $this->assertEquals('1. Janvāris 2017', $date->format('jS f Y'));
 
-        $date = new Moment('2017-01-12 01:00:00', 'Europe/Riga');
-        $this->assertEquals('12. Janvāris 2017', $date->format('jS f Y'));
+        $date = new Moment('2017-03-12 01:00:00', 'Europe/Riga');
+        $this->assertEquals('12. Marts 2017', $date->format('jS f Y'));
 
-        $date = new Moment('2017-01-23 01:00:00', 'Europe/Riga');
-        $this->assertEquals('23. Janvāris 2017', $date->format('jS f Y'));
+        $date = new Moment('2017-06-23 01:00:00', 'Europe/Riga');
+        $this->assertEquals('23. Jūnijs 2017', $date->format('jS f Y'));
 
-        $date = new Moment('2017-01-25 01:00:00', 'Europe/Riga');
-        $this->assertEquals('25. Janvāris 2017', $date->format('jS f Y'));
+        $date = new Moment('2017-10-03 01:00:00', 'Europe/Riga');
+        $this->assertEquals('3. Oktobris 2017', $date->format('jS f Y'));
     }
 }


### PR DESCRIPTION
Greetings

Grammatical corrections in context
 - Moths names
 - Relative time
 - Calendar names

Updated unit tests