### PR TITLE
Fall back missing "monthsNominative" definition to "months"

### DIFF
--- a/src/MomentLocale.php
+++ b/src/MomentLocale.php
@@ -82,6 +82,12 @@ class MomentLocale
         {
             if (isset($string[$key]) === false)
             {
+                if ($key == 'monthsNominative' && isset($string['months']))
+                {
+                    $string = $string['months'];
+                    continue;
+                }
+
                 throw new MomentException('Locale string does not exist for key: ' . join(' > ', $keys));
             }
 

--- a/tests/unit/Moment/MomentGermanLocaleTest.php
+++ b/tests/unit/Moment/MomentGermanLocaleTest.php
@@ -86,4 +86,10 @@ class MomentGermanLocaleTest extends TestCase
         $moment = new Moment('2016-01-03 16:17:07', 'Europe/Berlin');
         $this->assertEquals('03. Dezember', $moment->subtractMonths(1)->format('d. F'));
     }
+
+    public function testMonthsNominativeFallback()
+    {
+        $moment = new Moment('2016-01-03 16:17:07', 'Europe/Berlin');
+        $this->assertEquals('Januar 2016', $moment->format('f Y'));
+    }
 }


### PR DESCRIPTION
Closes #93

Prevent `MomentException` if "f" format is used with locale without "monthsNominative" definition.