### PR TITLE
fix - fr_FR ordinal not working

### DIFF
--- a/src/Locales/fr_FR.php
+++ b/src/Locales/fr_FR.php
@@ -34,7 +34,7 @@ return array(
     ),
     "ordinal"       => function ($number)
     {
-        return $number . ($number === 1 ? '[er]' : '');
+        return $number . ($number === 1 || $number === '1' ? '[er]' : '');
     },
     "week"          => array(
         "dow" => 1, // Monday is the first day of the week.


### PR DESCRIPTION
Ordinal seems to not be working, because of the strict condition `$number === 1` while `$number` is actually passed as a `string` added an `OR` case where `$number === '1'` so `$number` can be a string too