### PR TITLE
Fix time format in es_ES.php

### DIFF
--- a/src/Locales/es_ES.php
+++ b/src/Locales/es_ES.php
@@ -16,7 +16,7 @@ return array(
         "lastDay"  => '[ayer]',
         "lastWeek" => '[el] l',
         "sameElse" => 'l',
-        "withTime" => function (Moment $moment) { return '[a la' . ($moment->getHour() !== 1 ? 's' : null) . '] H:i'; },
+        "withTime" => function (Moment $moment) { return '[a la' . ($moment->getHour() != 1 ? 's' : null) . '] G:i [h]'; },
         "default"  => 'd/m/Y',
     ),
     "relativeTime"  => array(


### PR DESCRIPTION
Identical comparison with getHour was not working, so times such as "1:00" were being preceded by the plural "las" instead the proper singular form "la".
Also, for the type of written language used in the calendar output, not leading zeroes ("G" instead of "H") and " h" suffix is more suitable.