### PR TITLE
Fix time format in fr_FR

### DIFF
--- a/src/Locales/fr_FR.php
+++ b/src/Locales/fr_FR.php
@@ -14,7 +14,7 @@ return array(
         "lastDay"  => '[Hier]',
         "lastWeek" => 'l [dernier]',
         "sameElse" => 'l',
-        "withTime" => '[à] H:i',
+        "withTime" => '[à] G [h] i',
         "default"  => 'd/m/Y',
     ),
     "relativeTime"  => array(


### PR DESCRIPTION
Proper time format in French is, for example: "9 h 30" (09:30), that is, no leading zeroes in hours and " h " as a separator.