### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
   allow_failures:
     - php: hhvm
       env: PHP_VERSION=7.0.1
+    - php: nightly
   include:
     - php: 5.3
       dist: precise
@@ -11,6 +12,8 @@ matrix:
     - php: 5.6
     - php: 7.0
     - php: 7.1
+    - php: 7.2
+    - php: nightly
 
 before_install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,16 @@
         "php": ">=5.3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36"
+        "phpunit/phpunit": "^4.8.36 || ^5.5 || ^6.5"
     },
     "autoload": {
         "psr-4": {
             "Moment\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Moment\\": "tests/"
         }
     }
 }

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -6,4 +6,9 @@
             <directory>unit</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">../src/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/unit/Moment/MomentLatvianLocaleTest.php
+++ b/tests/unit/Moment/MomentLatvianLocaleTest.php
@@ -2,7 +2,9 @@
 
 namespace Moment;
 
-class MomentLatvianLocaleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class MomentLatvianLocaleTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
# Changed log
- Use the class-based PHPUnit namespace.
- Set the multiple PHPUnit version for the different PHP versions tests.
- Add the ```nightly``` test and that can be failed during Travis CI build.
- Add the ```php-7.2``` tests in Travis CI build setting.