### PR TITLE
Remove typehint to fix php < 7.2 compatibility

### DIFF
--- a/src/Moment.php
+++ b/src/Moment.php
@@ -2,8 +2,6 @@
 
 namespace Moment;
 
-use DateTimeZone;
-
 /**
  * Moment
  * Wrapper for PHP's DateTime class inspired by moment.js
@@ -86,13 +84,13 @@ class Moment extends \DateTime
      *
      * @param string                $format format of the date
      * @param string                $time date string to parse
-     * @param null|DateTimeZone     $timezone optional timezone to parse the string with
+     * @param null|\DateTimeZone    $timezone optional timezone to parse the string with
      * @param null|FormatsInterface $formatsInterface optional interface to use for {@see $format}.
      *
      * @return static
      * @throws MomentException
      */
-    public static function createFromFormat($format, $time, DateTimeZone $timezone = null, FormatsInterface $formatsInterface = null)
+    public static function createFromFormat($format, $time, $timezone = null, FormatsInterface $formatsInterface = null)
     {
         // handle diverse format types
         if ($formatsInterface instanceof FormatsInterface)


### PR DESCRIPTION
Fix `Moment::createFromFormat` declaration to be compatible with php < 7.2.  `DateTimeZone` typehint was added in 9d1011ca3836766237cf92a7f8cf9274ad44fa9c to improve phpdoc.
closes #170
```
There was 1 error:
1) Moment\MomentBritishEnglishLocaleTest::testWeekdayNames
Declaration of Moment\Moment::createFromFormat($format, $time, ?DateTimeZone $timezone = NULL, ?Moment\FormatsInterface $formatsInterface = NULL) should be compatible with DateTime::createFromFormat($format, $time, $object = NULL)
/home/travis/build/fightbulc/moment.php/src/Moment.php:1428
/home/travis/build/fightbulc/moment.php/tests/unit/Moment/MomentBritishEnglishLocaleTest.php:15
```