### PR TITLE
Prevent crashes if overriding class and accessing implicitCloning functions

### DIFF
--- a/src/Moment.php
+++ b/src/Moment.php
@@ -760,7 +760,7 @@ class Moment extends \DateTime
      *
      * @return Moment
      */
-    private function addTime($type = 'day', $value = 1)
+    protected function addTime($type = 'day', $value = 1)
     {
         if ($this->immutableMode)
         {
@@ -1223,7 +1223,7 @@ class Moment extends \DateTime
      *
      * @return Moment
      */
-    private function setRawDateTimeString($rawDateTimeString)
+    protected function setRawDateTimeString($rawDateTimeString)
     {
         if ($this->immutableMode)
         {
@@ -1248,7 +1248,7 @@ class Moment extends \DateTime
      *
      * @return Moment
      */
-    private function setTimezoneString($timezoneString)
+    protected function setTimezoneString($timezoneString)
     {
         if ($this->immutableMode)
         {
@@ -1400,7 +1400,7 @@ class Moment extends \DateTime
      *
      * @return Moment
      */
-    private function subtractTime($type = 'day', $value = 1)
+    protected function subtractTime($type = 'day', $value = 1)
     {
         if ($this->immutableMode)
         {


### PR DESCRIPTION
Make any functions that can be called through implicitCloning() protected so subclasses don't crash accessing private functions.

This came about due to me making a "MomentImmutable" subclass that acts like DateTimeImmutable.  If you want, I can submit this as a PR too.