### PR TITLE
Fix test classes naming typo

### DIFF
--- a/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
@@ -17,7 +17,7 @@ namespace Moment;
 use Moment\CustomFormats\MomentJs;
 use PHPUnit\Framework\TestCase;
 
-class MomentCandianEnglishLocaleTest extends TestCase
+class MomentCanadianEnglishLocaleTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
@@ -16,7 +16,7 @@ namespace Moment;
 
 use PHPUnit\Framework\TestCase;
 
-class MomentCandianFrenchLocaleTest extends TestCase
+class MomentCanadianFrenchLocaleTest extends TestCase
 {
     public function setUp()
     {


### PR DESCRIPTION
Just fixing typo of "Candian" 🇨🇦 tests