### PR TITLE
Function `isValidDate` made public.

### DIFF
--- a/src/Moment.php
+++ b/src/Moment.php
@@ -1303,7 +1303,7 @@ class Moment extends \DateTime
      * @return bool
      * @throws MomentException
      */
-    private function isValidDate()
+    public function isValidDate()
     {
         $rawDateTime = $this->getRawDateTimeString();
 


### PR DESCRIPTION
Function `isValidDate` made public for use it in code.
Until now, we could only check valid date when use `format()` when [throw error `Moment\MomentException`](https://github.com/fightbulc/moment.php/blob/master/src/Moment.php#L202-L205).