### PR TITLE
fix: PHP 8.1 deprecation warnings

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,165 +1,6 @@
 name: qa
 on: [push, pull_request]
 jobs:
-  PHP5_3:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '5.3'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP5_4:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '5.4'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP5_5:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '5.5'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP5_6:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '5.6'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP7_0:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.0'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP7_1:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.1'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP7_2:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.2'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
-
-  PHP7_3:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.3'
-
-      - name: Validate composer.json and composer.lock
-        run: composer validate
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress --no-suggest
-
-      - name: Run PHPUnit
-        run: vendor/bin/phpunit -c tests/build.xml
 
   PHP7_4:
     runs-on: ubuntu-latest
@@ -191,6 +32,26 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c tests/build.xml
+
+  PHP8_1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/src/Moment.php
+++ b/src/Moment.php
@@ -91,6 +91,7 @@ class Moment extends \DateTime
      * @return static|false         Returns a new Moment instance or FALSE on failure.
      * @throws MomentException
      */
+    #[\ReturnTypeWillChange]
     public static function createFromFormat($format, $time, $timezone = null, FormatsInterface $formatsInterface = null)
     {
         // handle diverse format types
@@ -212,6 +213,7 @@ class Moment extends \DateTime
      *
      * @return \DateTime|Moment
      */
+    #[\ReturnTypeWillChange]
     public function setTimezone($timezone)
     {
         if ($this->immutableMode)
@@ -238,6 +240,7 @@ class Moment extends \DateTime
      * @return string
      * @throws MomentException
      */
+    #[\ReturnTypeWillChange]
     public function format($format = null, $formatsInterface = null)
     {
         // set default format
@@ -591,6 +594,7 @@ class Moment extends \DateTime
      *
      * @return self|\DateTime
      */
+    #[\ReturnTypeWillChange]
     public function setDate($year, $month, $day)
     {
         if ($this->immutableMode)
@@ -692,6 +696,7 @@ class Moment extends \DateTime
      *
      * @return $this|\DateTime
      */
+    #[\ReturnTypeWillChange]
     public function setTime($hour, $minute, $second = null, $microseconds = null)
     {
         if ($this->immutableMode)

--- a/tests/build.xml
+++ b/tests/build.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="bootstrap.php" backupGlobals="false" colors="true" backupStaticAttributes="false" strict="true" verbose="true">
-    <testsuites>
-        <testsuite name="unit">
-            <directory>unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">../src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="bootstrap.php" backupGlobals="false" colors="true" backupStaticAttributes="false" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">../src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory>unit</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/tests/unit/Moment/MomentBritishEnglishLocaleTest.php
+++ b/tests/unit/Moment/MomentBritishEnglishLocaleTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentBritishEnglishLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('en_GB');
     }

--- a/tests/unit/Moment/MomentBritishEnglishLocaleTest.php
+++ b/tests/unit/Moment/MomentBritishEnglishLocaleTest.php
@@ -15,7 +15,7 @@ class MomentBritishEnglishLocaleTest extends TestCase
         Moment::setLocale('en_GB');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -39,7 +39,7 @@ class MomentBritishEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -68,7 +68,7 @@ class MomentBritishEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $a = array(
             array('l, d F Y, G:i:s', 'Saturday, 12 June 2010, 22:00:00'),
@@ -105,7 +105,7 @@ class MomentBritishEnglishLocaleTest extends TestCase
 //        }
 //    }
 
-    public function testOrdinalsFormat()
+    public function testOrdinalsFormat(): void
     {
         $moment = new Moment('2010-06-02T00:00:00+0000');
         self::assertEquals('2nd', $moment->format('jS'));
@@ -113,7 +113,7 @@ class MomentBritishEnglishLocaleTest extends TestCase
         self::assertEquals('12th', $moment->format('jS'));
     }
 
-	public function testRelative()
+	public function testRelative(): void
 	{
 		Moment::setLocale('en_GB');
 

--- a/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
@@ -24,7 +24,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         Moment::setLocale('en_CA');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -48,7 +48,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -77,7 +77,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $a = array(
             array('l, d F Y, G:i:s', 'Saturday, 12 June 2010, 22:00:00'),
@@ -93,7 +93,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testCustomLocaleFormat()
+    public function testCustomLocaleFormat(): void
     {
         $a = array(
             array('LT', '10:00 PM',),
@@ -114,7 +114,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         }
     }
 
-    public function testOrdinalsFormat()
+    public function testOrdinalsFormat(): void
     {
         $moment = new Moment('2010-06-02T00:00:00+0000');
         self::assertEquals('2nd', $moment->format('jS'));
@@ -122,7 +122,7 @@ class MomentCanadianEnglishLocaleTest extends TestCase
         self::assertEquals('12th', $moment->format('jS'));
     }
 
-	public function testRelative()
+	public function testRelative(): void
 	{
 		$beginningMoment = new Moment('2010-06-12 00:00:00', 'Europe/London');
 

--- a/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianEnglishLocaleTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentCanadianEnglishLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('en_CA');
     }

--- a/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
@@ -23,7 +23,7 @@ class MomentCanadianFrenchLocaleTest extends TestCase
         Moment::setLocale('fr_CA');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -48,7 +48,7 @@ class MomentCanadianFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -78,7 +78,7 @@ class MomentCanadianFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $a = array(
             array('l, F d Y, g:i:s a', 'dimanche, février 14 2010, 3:25:50 pm'),
@@ -94,7 +94,7 @@ class MomentCanadianFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testOrdinalsFormat()
+    public function testOrdinalsFormat(): void
     {
         $moment = new Moment('2010-06-02T00:00:00+0000');
         self::assertEquals('2', $moment->format('jS'));
@@ -102,7 +102,7 @@ class MomentCanadianFrenchLocaleTest extends TestCase
         self::assertEquals('1er', $moment->format('jS'));
     }
 
-    public function testRelative()
+    public function testRelative(): void
     {
         $beginningMoment = new Moment('2015-06-14 20:46:22', 'Europe/Berlin');
         $endMoment = new Moment('2015-06-14 20:48:32', 'Europe/Berlin');

--- a/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentCanadianFrenchLocaleTest.php
@@ -18,7 +18,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentCanadianFrenchLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('fr_CA');
     }

--- a/tests/unit/Moment/MomentEsperantoLocaleTest.php
+++ b/tests/unit/Moment/MomentEsperantoLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentEsperantoLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('eo');
     }

--- a/tests/unit/Moment/MomentEsperantoLocaleTest.php
+++ b/tests/unit/Moment/MomentEsperantoLocaleTest.php
@@ -11,7 +11,7 @@ class MomentEsperantoLocaleTest extends TestCase
         Moment::setLocale('eo');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -35,7 +35,7 @@ class MomentEsperantoLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -64,7 +64,7 @@ class MomentEsperantoLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $targetDate = new Moment('2010-06-09 15:25:50');
         $formats = array(
@@ -82,7 +82,7 @@ class MomentEsperantoLocaleTest extends TestCase
         }
     }
 
-    public function _testRelative()
+    public function _testRelative(): void
     {
         $beginningMoment = new Moment('2015-06-14 20:46:22', 'Europe/Berlin');
         $endMoment = new Moment('2015-06-14 20:48:32', 'Europe/Berlin');
@@ -90,7 +90,7 @@ class MomentEsperantoLocaleTest extends TestCase
         self::assertEquals('antaŭ 2 minutoj', $beginningMoment->from($endMoment)->getRelative());
     }
 
-    public function testRelative()
+    public function testRelative(): void
     {
         $tz = 'Europe/Berlin';
         $beginningMoment = new Moment('2010-06-12 00:00:00', $tz);

--- a/tests/unit/Moment/MomentFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentFrenchLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentFrenchLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('fr_FR');
     }

--- a/tests/unit/Moment/MomentFrenchLocaleTest.php
+++ b/tests/unit/Moment/MomentFrenchLocaleTest.php
@@ -11,7 +11,7 @@ class MomentFrenchLocaleTest extends TestCase
         Moment::setLocale('fr_FR');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -36,7 +36,7 @@ class MomentFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -66,7 +66,7 @@ class MomentFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $a = array(
             array('l, F d Y, g:i:s a',                  'dimanche, février 14 2010, 3:25:50 pm'),
@@ -82,7 +82,7 @@ class MomentFrenchLocaleTest extends TestCase
         }
     }
 
-    public function testRelative()
+    public function testRelative(): void
     {
         $beginningMoment = new Moment('2015-06-14 20:46:22', 'Europe/Berlin');
         $endMoment = new Moment('2015-06-14 20:48:32', 'Europe/Berlin');

--- a/tests/unit/Moment/MomentGermanLocaleTest.php
+++ b/tests/unit/Moment/MomentGermanLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentGermanLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('de_DE');
     }

--- a/tests/unit/Moment/MomentGermanLocaleTest.php
+++ b/tests/unit/Moment/MomentGermanLocaleTest.php
@@ -11,7 +11,7 @@ class MomentGermanLocaleTest extends TestCase
         Moment::setLocale('de_DE');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -36,7 +36,7 @@ class MomentGermanLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -66,7 +66,7 @@ class MomentGermanLocaleTest extends TestCase
         }
     }
 
-    public function testHirbodIssueLocaleDate001()
+    public function testHirbodIssueLocaleDate001(): void
     {
         // @see: https://github.com/fightbulc/moment.php/issues/50
 
@@ -79,7 +79,7 @@ class MomentGermanLocaleTest extends TestCase
         self::assertEquals('08. März', $moment->format('d. F'));
     }
 
-    public function testHirbodIssueLocaleDate002()
+    public function testHirbodIssueLocaleDate002(): void
     {
         // @see: https://github.com/fightbulc/moment.php/issues/61
 
@@ -87,7 +87,7 @@ class MomentGermanLocaleTest extends TestCase
         self::assertEquals('03. Dezember', $moment->subtractMonths(1)->format('d. F'));
     }
 
-    public function testMonthsNominativeFallback()
+    public function testMonthsNominativeFallback(): void
     {
         $moment = new Moment('2016-01-03 16:17:07', 'Europe/Berlin');
         self::assertEquals('Januar 2016', $moment->format('f Y'));

--- a/tests/unit/Moment/MomentLatvianLocaleTest.php
+++ b/tests/unit/Moment/MomentLatvianLocaleTest.php
@@ -11,7 +11,7 @@ class MomentLatvianLocaleTest extends TestCase
         Moment::setLocale('lv_LV');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2017-10-20T00:00:00+0000';
 
@@ -46,7 +46,7 @@ class MomentLatvianLocaleTest extends TestCase
         }
     }
 
-    public function testMonthFormat()
+    public function testMonthFormat(): void
     {
         $startingDate = '2016-01-01T00:00:00+0000';
 
@@ -94,7 +94,7 @@ class MomentLatvianLocaleTest extends TestCase
         }
     }
 
-    public function testDayMonthFormat001()
+    public function testDayMonthFormat001(): void
     {
         $string = '2015-06-14 20:46:22';
         $moment = new Moment($string, 'Europe/Riga');
@@ -105,7 +105,7 @@ class MomentLatvianLocaleTest extends TestCase
         self::assertEquals('8 Martā', $moment->format('j F'));
     }
 
-    public function testMinutes()
+    public function testMinutes(): void
     {
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Riga');
 
@@ -113,7 +113,7 @@ class MomentLatvianLocaleTest extends TestCase
         self::assertEquals('pirms 17 minūtēm', $relative->getRelative());
     }
 
-    public function testShowRelativeCalendarDates()
+    public function testShowRelativeCalendarDates(): void
     {
         $past = new Moment('2016-04-10 16:30:07');
         self::assertEquals('Pagājušā Svētdiena plkst. 16:30', $past->calendar(true, new Moment('2016-04-12')));
@@ -137,7 +137,7 @@ class MomentLatvianLocaleTest extends TestCase
         self::assertEquals('15.04.2116', $past->calendar(false, new Moment('2017-04-23')));
     }
 
-    public function testFutureRelative()
+    public function testFutureRelative(): void
     {
         $date = new Moment('2017-01-11 01:00:00');
 
@@ -153,7 +153,7 @@ class MomentLatvianLocaleTest extends TestCase
         self::assertEquals('pēc 7 gadiem', $date->from('2010-01-11 00:00:00')->getRelative(), 'year');
     }
 
-    public function testPastRelative()
+    public function testPastRelative(): void
     {
         $date = new Moment('2010-01-11 01:00:00');
         self::assertEquals('pirms dažām sekundēm', $date->from('2010-01-11 01:00:01')->getRelative(), 'seconds');
@@ -168,7 +168,7 @@ class MomentLatvianLocaleTest extends TestCase
         self::assertEquals('pirms 5 gadiem', $date->from('2015-01-11 01:00:00')->getRelative(), 'year');
     }
 
-    public function testOrdinalFormat()
+    public function testOrdinalFormat(): void
     {
         $date = new Moment('2017-01-01 01:00:00', 'Europe/Riga');
         self::assertEquals('1. Janvāris 2017', $date->format('jS f Y'));

--- a/tests/unit/Moment/MomentLatvianLocaleTest.php
+++ b/tests/unit/Moment/MomentLatvianLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentLatvianLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('lv_LV');
     }

--- a/tests/unit/Moment/MomentPolishLocaleTest.php
+++ b/tests/unit/Moment/MomentPolishLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentPolishLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('pl_PL');
     }

--- a/tests/unit/Moment/MomentPolishLocaleTest.php
+++ b/tests/unit/Moment/MomentPolishLocaleTest.php
@@ -11,7 +11,7 @@ class MomentPolishLocaleTest extends TestCase
         Moment::setLocale('pl_PL');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2016-01-29T00:00:00+0000';
 
@@ -35,7 +35,7 @@ class MomentPolishLocaleTest extends TestCase
         }
     }
 
-    public function testDayMonthFormat001()
+    public function testDayMonthFormat001(): void
     {
         $string = '2015-06-14 20:46:22';
         $moment = new Moment($string, 'Europe/Berlin');
@@ -46,13 +46,13 @@ class MomentPolishLocaleTest extends TestCase
         self::assertEquals('8 marca', $moment->format('j F'));
     }
 
-    public function testDayMonthFormat002()
+    public function testDayMonthFormat002(): void
     {
         $moment = new Moment('2016-01-03 16:17:07', 'Europe/Berlin');
         self::assertEquals('3 grudnia', $moment->subtractMonths(1)->format('j F'));
     }
 
-    public function testMonthFormatFN()
+    public function testMonthFormatFN(): void
     {
         $startingDate = '2016-01-01T00:00:00+0000';
 
@@ -81,7 +81,7 @@ class MomentPolishLocaleTest extends TestCase
     }
 
 
-    public function testMinutes()
+    public function testMinutes(): void
     {
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Berlin');
 
@@ -95,7 +95,7 @@ class MomentPolishLocaleTest extends TestCase
         self::assertEquals('13 minut temu', $relative->getRelative());
     }
 
-    public function testLastWeekWeekend()
+    public function testLastWeekWeekend(): void
     {
         $past = new Moment('2016-04-10');
         self::assertEquals('ostatnia niedziela', $past->calendar(false, new Moment('2016-04-12')));

--- a/tests/unit/Moment/MomentRussianLocaleTest.php
+++ b/tests/unit/Moment/MomentRussianLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentRussianLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('ru_RU');
     }

--- a/tests/unit/Moment/MomentRussianLocaleTest.php
+++ b/tests/unit/Moment/MomentRussianLocaleTest.php
@@ -11,7 +11,7 @@ class MomentRussianLocaleTest extends TestCase
         Moment::setLocale('ru_RU');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2016-01-29T00:00:00+0000';
 
@@ -35,7 +35,7 @@ class MomentRussianLocaleTest extends TestCase
         }
     }
 
-    public function testDayMonthFormat001()
+    public function testDayMonthFormat001(): void
     {
         $string = '2015-06-14 20:46:22';
         $moment = new Moment($string, 'Europe/Moscow');
@@ -46,13 +46,13 @@ class MomentRussianLocaleTest extends TestCase
         self::assertEquals('8 марта', $moment->format('j F'));
     }
 
-    public function testDayMonthFormat002()
+    public function testDayMonthFormat002(): void
     {
         $moment = new Moment('2016-01-03 16:17:07', 'Europe/Moscow');
         self::assertEquals('3 декабря', $moment->subtractMonths(1)->format('j F'));
     }
 
-    public function testMonthFormatFN()
+    public function testMonthFormatFN(): void
     {
         $startingDate = '2016-01-01T00:00:00+0000';
 
@@ -81,7 +81,7 @@ class MomentRussianLocaleTest extends TestCase
     }
 
 
-    public function testMinutes()
+    public function testMinutes(): void
     {
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Moscow');
 
@@ -95,7 +95,7 @@ class MomentRussianLocaleTest extends TestCase
         self::assertEquals('13 минут назад', $relative->getRelative());
     }
 
-    public function testSeconds()
+    public function testSeconds(): void
     {
        $past = new Moment('2017-08-30 20:49:30', 'Europe/Samara');
 
@@ -109,7 +109,7 @@ class MomentRussianLocaleTest extends TestCase
        self::assertEquals('5 секунд назад', $relative->getRelative());
        }
 
-    public function testLastWeekWeekend()
+    public function testLastWeekWeekend(): void
     {
         $past = new Moment('2016-04-10 16:30:07');
         self::assertEquals('воскресенье в 16:30', $past->calendar(true, new Moment('2016-04-12')));
@@ -136,7 +136,7 @@ class MomentRussianLocaleTest extends TestCase
         self::assertEquals('суббота', $past->calendar(false, new Moment('2016-04-18')));
     }
 
-    public function testFutureRelative()
+    public function testFutureRelative(): void
     {
         $date = new Moment('2017-01-11 01:00:00');
 
@@ -150,7 +150,7 @@ class MomentRussianLocaleTest extends TestCase
     }
 
 
-    public function testOrdinalFormat()
+    public function testOrdinalFormat(): void
     {
         $date = new Moment('2017-01-01 01:00:00');
         self::assertEquals('1е января 2017', $date->format('jS F Y'));

--- a/tests/unit/Moment/MomentSimilarLocaleTest.php
+++ b/tests/unit/Moment/MomentSimilarLocaleTest.php
@@ -7,7 +7,7 @@ class MomentSimilarLocaleTest extends MomentBritishEnglishLocaleTest
     /**
      * @throws MomentException
      */
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('en', true);
     }

--- a/tests/unit/Moment/MomentTurkishLocaleTest.php
+++ b/tests/unit/Moment/MomentTurkishLocaleTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentTurkishLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('tr_TR');
     }

--- a/tests/unit/Moment/MomentTurkishLocaleTest.php
+++ b/tests/unit/Moment/MomentTurkishLocaleTest.php
@@ -16,7 +16,7 @@ class MomentTurkishLocaleTest extends TestCase
         Moment::setLocale('tr_TR');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -39,7 +39,7 @@ class MomentTurkishLocaleTest extends TestCase
         }
     }
 
-    public function testMonthNames()
+    public function testMonthNames(): void
     {
         $startingDate = '2015-01-04T00:00:00+0000';
 
@@ -68,7 +68,7 @@ class MomentTurkishLocaleTest extends TestCase
         }
     }
 
-    public function testFormat()
+    public function testFormat(): void
     {
         $a = array(
             array('l, F d Y, g:i:s a',                  'Pazar, Şubat 14 2010, 3:25:50 pm'),
@@ -84,7 +84,7 @@ class MomentTurkishLocaleTest extends TestCase
         }
     }
 
-    public function testRelative()
+    public function testRelative(): void
     {
         $beginningMoment = new Moment('2015-06-14 20:46:22', 'Europe/Istanbul');
         $endMoment = new Moment('2015-06-14 20:48:32', 'Europe/Istanbul');
@@ -92,7 +92,7 @@ class MomentTurkishLocaleTest extends TestCase
         self::assertEquals('2 dakika önce', $beginningMoment->from($endMoment)->getRelative());
     }
 
-    public function testMinutes()
+    public function testMinutes(): void
     {
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Kiev');
 
@@ -106,7 +106,7 @@ class MomentTurkishLocaleTest extends TestCase
         self::assertEquals('13 dakika önce', $relative->getRelative());
     }
 
-    public function testLastWeekWeekend()
+    public function testLastWeekWeekend(): void
     {
         $past = new Moment('2016-04-10 16:30:07');
         self::assertEquals('Geçen hafta Pazar 16:30', $past->calendar(true, new Moment('2016-04-12')));

--- a/tests/unit/Moment/MomentUkrainianLocaleTest.php
+++ b/tests/unit/Moment/MomentUkrainianLocaleTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class MomentUkrainianLocaleTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Moment::setLocale('uk_UA');
     }

--- a/tests/unit/Moment/MomentUkrainianLocaleTest.php
+++ b/tests/unit/Moment/MomentUkrainianLocaleTest.php
@@ -11,7 +11,7 @@ class MomentUkrainianLocaleTest extends TestCase
         Moment::setLocale('uk_UA');
     }
 
-    public function testWeekdayNames()
+    public function testWeekdayNames(): void
     {
         $startingDate = '2016-01-29T00:00:00+0000';
 
@@ -35,7 +35,7 @@ class MomentUkrainianLocaleTest extends TestCase
         }
     }
 
-    public function testDayMonthFormat001()
+    public function testDayMonthFormat001(): void
     {
         $string = '2015-06-14 20:46:22';
         $moment = new Moment($string, 'Europe/Kiev');
@@ -46,13 +46,13 @@ class MomentUkrainianLocaleTest extends TestCase
         self::assertEquals('8 березня', $moment->format('j F'));
     }
 
-    public function testDayMonthFormat002()
+    public function testDayMonthFormat002(): void
     {
         $moment = new Moment('2016-01-03 16:17:07', 'Europe/Kiev');
         self::assertEquals('3 грудня', $moment->subtractMonths(1)->format('j F'));
     }
 
-    public function testMonthFormatFN()
+    public function testMonthFormatFN(): void
     {
         $startingDate = '2016-01-01T00:00:00+0000';
 
@@ -81,7 +81,7 @@ class MomentUkrainianLocaleTest extends TestCase
     }
 
 
-    public function testMinutes()
+    public function testMinutes(): void
     {
         $past = new Moment('2016-01-03 16:17:07', 'Europe/Kiev');
 
@@ -95,7 +95,7 @@ class MomentUkrainianLocaleTest extends TestCase
         self::assertEquals('13 хвилин тому', $relative->getRelative());
     }
 
-    public function testLastWeekWeekend()
+    public function testLastWeekWeekend(): void
     {
         $past = new Moment('2016-04-10 16:30:07');
         self::assertEquals('неділя о 16:30', $past->calendar(true, new Moment('2016-04-12')));


### PR DESCRIPTION
chore: define return type for locale test scripts method `setUp(): void`
chore: migrated PHPUnit configuration using `--migrate-configuration`
fix: suppress deprecation warnings generated in PHP 8.1 with `#[\ReturnTypeWillChange]`
chore: remove unsupported PHP versions
fixes #210 #207 