### PR TITLE
Fix: Disable result cache

### DIFF
--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -5,6 +5,7 @@
   backupGlobals="false"
   backupStaticAttributes="false"
   bootstrap="../vendor/autoload.php"
+  cacheResult="false"
   colors="true"
   verbose="true"
 >


### PR DESCRIPTION
This pull request

- [x] disables the result cache for `phpunit/phpunit`